### PR TITLE
feat(controller): reconcile core Trussium runtime resources

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -12,6 +12,7 @@ resources:
 - api:
     crdVersion: v1
     namespaced: true
+  controller: true
   domain: trussium.io
   group: runtime
   kind: TrussiumRuntime

--- a/README.md
+++ b/README.md
@@ -6,37 +6,76 @@ The Trussium Operator is the Kubernetes-native lifecycle manager for
 It provides a declarative Kubernetes API for deploying, configuring, upgrading,
 and observing released Trussium runtime containers.
 
-> **Project status:** Pre-alpha. The repository currently contains the
-> engineering foundation. The first `TrussiumRuntime` API has not yet been
-> released.
+> **Project status:** Pre-alpha. The initial `TrussiumRuntime v1alpha1` API and
+> core ConfigMap, ServiceAccount, Service, and Deployment reconciliation are
+> implemented. Runtime status and Kubernetes Events are the next milestone.
 
 ## Architecture
 
-The operator will watch `TrussiumRuntime` custom resources and reconcile the
-Kubernetes resources required to operate each runtime instance.
-
-```text
-TrussiumRuntime custom resource
-             │
-             ▼
-      Trussium Operator
-             │
-             ├── ServiceAccount
-             ├── ConfigMap
-             ├── Deployment
-             ├── Service
-             ├── PodDisruptionBudget
-             └── Status conditions
-                         │
-                         ▼
-       ghcr.io/trussium/trussium:<version>
-```
+    TrussiumRuntime custom resource
+                 │
+                 ▼
+          Trussium Operator
+                 │
+                 ├── ConfigMap
+                 ├── ServiceAccount
+                 ├── Service
+                 └── Deployment
+                             │
+                             ▼
+           ghcr.io/trussium/trussium:<version>
 
 The operator does not contain or compile the Trussium Python runtime. It
 consumes released runtime container images and manages their Kubernetes
 deployment lifecycle.
 
-## Repository responsibilities
+## Custom Resource
+
+The initial API is:
+
+    Group:   runtime.trussium.io
+    Version: v1alpha1
+    Kind:    TrussiumRuntime
+    Scope:   Namespaced
+
+Example:
+
+    apiVersion: runtime.trussium.io/v1alpha1
+    kind: TrussiumRuntime
+    metadata:
+      name: private-ai
+      namespace: trussium
+    spec:
+      image:
+        repository: ghcr.io/trussium/trussium
+        tag: v0.23.0
+
+      provider:
+        type: ollama
+        model: llama3.2
+        baseURL: http://ollama.ollama.svc.cluster.local:11434/v1
+
+See [docs/CUSTOM_RESOURCE.md](docs/CUSTOM_RESOURCE.md) for the complete API
+contract.
+
+## Core Reconciliation
+
+For every `TrussiumRuntime`, the operator manages:
+
+- ConfigMap
+- ServiceAccount
+- Service
+- Deployment
+
+The controller uses stable labels, controller owner references, deterministic
+resource names, and create-or-update reconciliation.
+
+It recreates deleted managed resources and corrects configuration drift.
+
+See [docs/RECONCILIATION.md](docs/RECONCILIATION.md) for the complete
+reconciliation contract.
+
+## Repository Responsibilities
 
 This repository owns:
 
@@ -72,23 +111,21 @@ The public [`trussium`](https://github.com/trussium/trussium) repository owns:
 
 See [DEVELOPMENT.md](DEVELOPMENT.md) for local setup and validation.
 
-The standard validation workflow is:
+Run:
 
-```bash
-make generate
-make manifests
-make fmt
-make vet
-make test
-make lint
-```
+    make generate
+    make manifests
+    make fmt
+    make vet
+    make test
+    make lint
 
 ## Roadmap
 
 The public operator roadmap is maintained in [ROADMAP.md](ROADMAP.md).
 
-The next planned milestone is the initial
-`runtime.trussium.io/v1alpha1` `TrussiumRuntime` API.
+The next milestone adds Kubernetes-native runtime status and reconciliation
+Events.
 
 ## Contributing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,25 +12,24 @@ through GitHub Issues.
 
 ## Current Focus
 
-The repository foundation has been established using Go, Kubebuilder, and
-controller-runtime.
+Core `TrussiumRuntime` reconciliation has been implemented.
 
-The next priority after the foundation is merged will be the first namespaced
-Kubernetes API:
+For every namespaced runtime resource, the controller now manages:
 
-```text
-Group:   runtime.trussium.io
-Version: v1alpha1
-Kind:    TrussiumRuntime
-Scope:   Namespaced
-```
+- ConfigMap
+- ServiceAccount
+- Service
+- Deployment
 
-The initial API will describe the desired Trussium runtime image, replicas,
-provider configuration references, runtime settings, resource boundaries, and
-Service configuration.
+Managed resources use deterministic names, stable labels, controller owner
+references, and create-or-update reconciliation.
 
-No runtime reconciliation will be introduced until the API contract is
-reviewed and merged.
+The controller recreates deleted resources, corrects managed configuration
+drift, projects provider credentials through Secret key references, and does
+not read Secret values.
+
+The next priority is Kubernetes-native runtime status and reconciliation
+Events.
 
 ---
 
@@ -126,24 +125,57 @@ Provider credentials will never be embedded directly in custom resources.
 
 ## Milestone O3 — Core Runtime Reconciliation
 
-**Status:** 🗓 Planned
+**Status:** ✅ Completed
 
 Reconcile a functional Trussium runtime from a `TrussiumRuntime` resource.
 
-### Deliverables
+### Delivered
 
+- `TrussiumRuntime` controller scaffold
+- Controller registration with the manager
+- Watches for `TrussiumRuntime`
+- Watches for owned ConfigMaps
+- Watches for owned ServiceAccounts
+- Watches for owned Services
+- Watches for owned Deployments
 - ConfigMap reconciliation
 - ServiceAccount reconciliation
 - Service reconciliation
 - Deployment reconciliation
 - Stable Kubernetes labels
+- Stable selectors
+- Deterministic resource names
 - Controller owner references
+- Kubernetes garbage-collection ownership
+- Create-or-update reconciliation
 - Drift correction
-- Idempotent reconciliation
-- Runtime container image projection
+- Deleted-resource recreation
+- Idempotent repeated reconciliation
+- Runtime image tag rendering
+- Runtime image digest rendering
+- Image-pull Secret projection
 - Runtime environment projection
+- Provider configuration projection
+- Provider credential Secret projection
+- Service configuration projection
+- Replica projection
 - Resource request and limit projection
+- Dedicated ServiceAccount
+- Disabled ServiceAccount token mounting
+- Disabled Kubernetes Service links
+- Least-privilege generated RBAC
+- No Secret read permissions
 - Unit-tested resource builders
+- Fake-client reconciliation tests
+- Managed-resource ownership tests
+- Drift-correction tests
+- Deleted-resource recreation tests
+- Idempotency tests
+- Core reconciliation documentation
+- Managed-resource ownership architecture decision record
+
+This milestone intentionally does not update `TrussiumRuntime.status` or emit
+Kubernetes Events.
 
 ---
 
@@ -349,8 +381,18 @@ Compatibility will be tracked by operator and runtime release:
 
 ## Immediate Priority
 
-The next priority after the foundation is merged is:
+The next priority is:
 
-1. Define the `TrussiumRuntime v1alpha1` API.
+1. Implement `TrussiumRuntime` status and Kubernetes Events.
 
-The API must be reviewed before Deployment reconciliation begins.
+The next milestone will add:
+
+- `observedGeneration`
+- Ready replica count
+- Available replica count
+- Current runtime image
+- Runtime Service endpoint
+- Standard Kubernetes conditions
+- Stable condition reasons
+- Reconciliation Events
+- Missing-reference and Deployment failure reporting

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	runtimev1alpha1 "github.com/trussium/trussium-operator/api/v1alpha1"
+	"github.com/trussium/trussium-operator/internal/controller"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -177,6 +178,13 @@ func main() {
 		os.Exit(1)
 	}
 
+	if err := (&controller.TrussiumRuntimeReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to create controller", "controller", "trussiumruntime")
+		os.Exit(1)
+	}
 	// +kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -1,11 +1,40 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  labels:
-    app.kubernetes.io/name: trussium-operator
-    app.kubernetes.io/managed-by: kustomize
   name: manager-role
 rules:
-- apiGroups: [""]
-  resources: ["pods"]
-  verbs: ["get", "list", "watch"]
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - runtime.trussium.io
+  resources:
+  - trussiumruntimes
+  verbs:
+  - get
+  - list
+  - watch

--- a/docs/RECONCILIATION.md
+++ b/docs/RECONCILIATION.md
@@ -1,0 +1,235 @@
+# Core Runtime Reconciliation
+
+The Trussium Operator reconciles a namespaced `TrussiumRuntime` resource into
+the Kubernetes resources required to run one Trussium runtime instance.
+
+## Managed Resources
+
+For each `TrussiumRuntime`, the controller manages:
+
+- ConfigMap
+- ServiceAccount
+- Service
+- Deployment
+
+Each managed resource:
+
+- Uses the same name and namespace as its `TrussiumRuntime`
+- Has stable Kubernetes application labels
+- Has a controller owner reference
+- Is recreated when deleted
+- Is corrected when its managed configuration drifts
+
+Kubernetes garbage collection removes managed resources when the owning
+`TrussiumRuntime` is deleted.
+
+No finalizer is required because this milestone does not manage external
+resources.
+
+## Reconciliation Flow
+
+A reconciliation iteration performs:
+
+1. Read the `TrussiumRuntime`.
+2. Ignore requests for resources that no longer exist.
+3. Ignore resources already being deleted.
+4. Create or update the ConfigMap.
+5. Create or update the ServiceAccount.
+6. Create or update the Service.
+7. Create or update the Deployment.
+8. Return without periodic requeueing.
+
+The controller also watches owned resources. A change or deletion affecting a
+managed ConfigMap, ServiceAccount, Service, or Deployment triggers another
+reconciliation of the owning `TrussiumRuntime`.
+
+## Resource Names
+
+The initial naming contract uses the custom-resource name directly.
+
+For a resource declared as:
+
+    metadata:
+      name: private-ai
+      namespace: trussium
+
+The controller creates:
+
+    ConfigMap/private-ai
+    ServiceAccount/private-ai
+    Service/private-ai
+    Deployment/private-ai
+
+All resources remain in the `trussium` namespace.
+
+## Labels
+
+Managed resources use:
+
+    app.kubernetes.io/name: trussium
+    app.kubernetes.io/instance: <TrussiumRuntime name>
+    app.kubernetes.io/component: runtime
+    app.kubernetes.io/managed-by: trussium-operator
+
+Services and Deployments select runtime pods using:
+
+    app.kubernetes.io/name: trussium
+    app.kubernetes.io/instance: <TrussiumRuntime name>
+
+The selector intentionally excludes mutable or descriptive labels.
+
+## ConfigMap
+
+The managed ConfigMap projects non-secret runtime configuration.
+
+Always projected:
+
+| Environment variable | Value |
+|---|---|
+| `TRUSSIUM_ENVIRONMENT` | `production` |
+| `TRUSSIUM_RUNTIME__HOST` | `0.0.0.0` |
+| `TRUSSIUM_RUNTIME__PORT` | `9000` |
+| `TRUSSIUM_PROVIDER__NAME` | Selected provider type |
+
+Conditionally projected:
+
+| Environment variable | Custom-resource source |
+|---|---|
+| `TRUSSIUM_PROVIDER__BASE_URL` | `spec.provider.baseURL` |
+| `TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS` | `spec.runtime.providerRequestTimeoutSeconds` |
+| `TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS` | `spec.runtime.streamIdleTimeoutSeconds` |
+| `TRUSSIUM_RUNTIME__GRACEFUL_SHUTDOWN_SECONDS` | `spec.runtime.shutdownDrainTimeoutSeconds` |
+
+Optional values remain absent when not configured. This allows the selected
+Trussium runtime release to apply its own defaults.
+
+`spec.provider.model` remains part of the public Kubernetes API, but this
+milestone does not invent a runtime environment variable for a process-wide
+default model.
+
+## Provider Credentials
+
+Provider credentials are projected directly from the referenced Kubernetes
+Secret into the runtime container:
+
+    TRUSSIUM_PROVIDER__API_KEY
+
+The operator does not:
+
+- Read the Secret value
+- Copy the Secret value into a ConfigMap
+- Store the value in status
+- Include the value in logs
+- Include the value in Kubernetes Events
+
+The controller therefore does not require Secret read permissions.
+
+## ServiceAccount
+
+The controller creates a dedicated ServiceAccount for each runtime.
+
+The ServiceAccount:
+
+- Uses the runtime name
+- Disables automatic Kubernetes API token mounting
+- Includes configured image-pull Secret references
+- Has a controller owner reference
+
+The runtime workload does not need Kubernetes API access during this
+milestone.
+
+## Service
+
+The managed Service:
+
+- Uses `spec.service.type`
+- Uses `spec.service.port`
+- Targets the container port named `http`
+- Selects only pods belonging to the owning runtime
+- Preserves Kubernetes-assigned Service fields such as `clusterIP`
+
+Supported Service types are:
+
+- `ClusterIP`
+- `NodePort`
+- `LoadBalancer`
+
+## Deployment
+
+The managed Deployment:
+
+- Uses `spec.replicas`
+- Uses the selected image tag or digest
+- Uses the dedicated ServiceAccount
+- Disables ServiceAccount token mounting
+- Disables Kubernetes Service environment-variable injection
+- Exposes TCP port `9000` as `http`
+- Loads non-secret settings through the managed ConfigMap
+- Projects provider credentials through a Secret key reference
+- Applies image-pull Secret references
+- Applies configured resource requests and limits
+
+Tag-based image example:
+
+    ghcr.io/trussium/trussium:v0.23.0
+
+Digest-based image example:
+
+    ghcr.io/trussium/trussium@sha256:<digest>
+
+## Ownership and Drift Correction
+
+Every managed resource has a controller owner reference pointing to its
+`TrussiumRuntime`.
+
+The controller uses create-or-update reconciliation:
+
+- Missing resources are created.
+- Managed fields are restored after drift.
+- Deleted managed resources are recreated.
+- Repeated reconciliation produces the same desired configuration.
+
+User-controlled fields outside the operator's managed contract should not be
+added directly to generated resources because the controller may overwrite
+them.
+
+Additional supported customization must be introduced through the
+`TrussiumRuntime` API.
+
+## RBAC
+
+The controller requires:
+
+- Read access to `TrussiumRuntime` resources
+- Create, read, update, patch, delete, list, and watch access for ConfigMaps
+- Equivalent management access for ServiceAccounts
+- Equivalent management access for Services
+- Equivalent management access for Deployments
+
+The controller does not currently require:
+
+- Secret reads
+- Status updates
+- Kubernetes Event creation
+- Pod reads
+- PodDisruptionBudget management
+
+## Current Scope Boundary
+
+This reconciliation milestone does not implement:
+
+- Runtime status conditions
+- Kubernetes Events
+- Deployment rollout monitoring
+- Runtime health evaluation
+- Secret existence validation
+- Startup, readiness, or liveness probes
+- Production container security contexts
+- PodDisruptionBudget
+- Topology spreading
+- HorizontalPodAutoscaler
+- NetworkPolicy
+- Configuration checksum annotations
+- Finalizers
+
+Status and Kubernetes Events are the next milestone.

--- a/docs/adr/0004-use-owner-references-for-managed-resources.md
+++ b/docs/adr/0004-use-owner-references-for-managed-resources.md
@@ -1,0 +1,114 @@
+# ADR 0004 — Use Owner References for Managed Resources
+
+- Status: Accepted
+- Date: August 2026
+
+## Context
+
+Each `TrussiumRuntime` requires several namespaced Kubernetes resources:
+
+- ConfigMap
+- ServiceAccount
+- Service
+- Deployment
+
+The operator must establish ownership, correct drift, recreate deleted
+resources, and safely remove managed resources when the custom resource is
+deleted.
+
+The current milestone does not create external infrastructure or resources
+outside Kubernetes garbage collection.
+
+## Decision
+
+Every resource managed for a `TrussiumRuntime` will have a Kubernetes
+controller owner reference pointing to that custom resource.
+
+The controller will use deterministic names and create-or-update
+reconciliation.
+
+The controller will watch:
+
+- `TrussiumRuntime`
+- Owned ConfigMaps
+- Owned ServiceAccounts
+- Owned Services
+- Owned Deployments
+
+No finalizer will be introduced during core reconciliation.
+
+## Naming Decision
+
+Managed resources use the owning `TrussiumRuntime` name and namespace.
+
+For example:
+
+    TrussiumRuntime/private-ai
+    ConfigMap/private-ai
+    ServiceAccount/private-ai
+    Service/private-ai
+    Deployment/private-ai
+
+This keeps discovery simple and avoids additional name-generation state.
+
+## Drift Decision
+
+The operator owns the fields required by the public `TrussiumRuntime`
+contract.
+
+During reconciliation, those fields are reset to their desired values.
+
+Unsupported direct modifications to generated resources may be overwritten.
+
+New user customization must be represented through explicit custom-resource
+fields rather than unmanaged mutations.
+
+## Secret Decision
+
+The operator projects provider credentials through Kubernetes Secret key
+references.
+
+It does not read Secret values during core reconciliation.
+
+Secret read permissions are therefore intentionally excluded from controller
+RBAC.
+
+## Deletion Decision
+
+Kubernetes garbage collection removes namespaced managed resources when the
+owning `TrussiumRuntime` is deleted.
+
+A finalizer is unnecessary because no external cleanup is required.
+
+A future capability may introduce a finalizer only when Kubernetes owner
+references cannot safely complete the required cleanup.
+
+## Consequences
+
+### Positive
+
+- Kubernetes-native lifecycle management
+- Automatic garbage collection
+- Clear ownership
+- Reconciliation after secondary-resource changes
+- Deterministic resource discovery
+- Straightforward drift correction
+- No custom deletion state machine
+
+### Negative
+
+- Direct edits to managed fields are overwritten.
+- Resource names cannot vary independently from the custom resource.
+- Ownership conflicts must surface as reconciliation errors.
+- Future external-resource management may require a finalizer.
+
+## Follow-Up
+
+The next milestone will add:
+
+- Observed generation
+- Ready and available replica counts
+- Runtime endpoint
+- Kubernetes conditions
+- Reconciliation Events
+- Stable condition reasons

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,3 +15,4 @@ boundaries for the Trussium Operator.
 - [0001 — Use Go and Kubebuilder](0001-use-go-and-kubebuilder.md)
 - [0002 — Separate the operator from the runtime](0002-separate-operator-and-runtime.md)
 - [0003 — Define the TrussiumRuntime v1alpha1 API](0003-define-trussiumruntime-v1alpha1-api.md)
+- [0004 — Use Owner References for Managed Resources](0004-use-owner-references-for-managed-resources.md)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
+	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2
 	sigs.k8s.io/controller-runtime v0.24.1
 	sigs.k8s.io/yaml v1.6.0
 )
@@ -92,7 +93,6 @@ require (
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/streaming v0.36.0 // indirect
-	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect
 	sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.34.0 // indirect
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect

--- a/internal/controller/runtime_resources.go
+++ b/internal/controller/runtime_resources.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+
+	runtimev1alpha1 "github.com/trussium/trussium-operator/api/v1alpha1"
+)
+
+const (
+	runtimeContainerName = "trussium"
+	runtimeHTTPPortName  = "http"
+	runtimeHTTPPort      = int32(9000)
+
+	envEnvironment             = "TRUSSIUM_ENVIRONMENT"
+	envRuntimeHost             = "TRUSSIUM_RUNTIME__HOST"
+	envRuntimePort             = "TRUSSIUM_RUNTIME__PORT"
+	envRuntimeShutdownSeconds  = "TRUSSIUM_RUNTIME__GRACEFUL_SHUTDOWN_SECONDS"
+	envProviderName            = "TRUSSIUM_PROVIDER__NAME"
+	envProviderBaseURL         = "TRUSSIUM_PROVIDER__BASE_URL"
+	envProviderAPIKey          = "TRUSSIUM_PROVIDER__API_KEY"
+	envProviderRequestSeconds  = "TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS"
+	envProviderStreamIdle      = "TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS"
+	defaultRuntimeEnvironment  = "production"
+	defaultRuntimeHost         = "0.0.0.0"
+	defaultRuntimeReplicaCount = int32(1)
+	defaultServicePort         = int32(9000)
+)
+
+// runtimeLabels returns stable labels shared by resources managed for one
+// TrussiumRuntime.
+func runtimeLabels(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       runtimeContainerName,
+		"app.kubernetes.io/instance":   runtimeResource.Name,
+		"app.kubernetes.io/component":  "runtime",
+		"app.kubernetes.io/managed-by": "trussium-operator",
+	}
+}
+
+// runtimeSelectorLabels returns the immutable label set used by Services and
+// Deployments to select a runtime instance.
+func runtimeSelectorLabels(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":     runtimeContainerName,
+		"app.kubernetes.io/instance": runtimeResource.Name,
+	}
+}
+
+// runtimeImage returns the complete container image selected by the custom
+// resource.
+func runtimeImage(
+	imageSpec runtimev1alpha1.RuntimeImageSpec,
+) string {
+	if imageSpec.Digest != nil {
+		return imageSpec.Repository + "@" + *imageSpec.Digest
+	}
+
+	if imageSpec.Tag != nil {
+		return imageSpec.Repository + ":" + *imageSpec.Tag
+	}
+
+	return imageSpec.Repository
+}
+
+// desiredReplicas returns the schema default when a non-defaulted object is
+// supplied directly to a unit test or fake client.
+func desiredReplicas(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) int32 {
+	if runtimeResource.Spec.Replicas == nil {
+		return defaultRuntimeReplicaCount
+	}
+
+	return *runtimeResource.Spec.Replicas
+}
+
+// desiredServiceType returns the schema default when a non-defaulted object is
+// supplied directly to a unit test or fake client.
+func desiredServiceType(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) corev1.ServiceType {
+	if runtimeResource.Spec.Service.Type == "" {
+		return corev1.ServiceTypeClusterIP
+	}
+
+	return runtimeResource.Spec.Service.Type
+}
+
+// desiredServicePort returns the schema default when a non-defaulted object is
+// supplied directly to a unit test or fake client.
+func desiredServicePort(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) int32 {
+	if runtimeResource.Spec.Service.Port == 0 {
+		return defaultServicePort
+	}
+
+	return runtimeResource.Spec.Service.Port
+}
+
+// imagePullSecrets converts API references to Kubernetes local references.
+func imagePullSecrets(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) []corev1.LocalObjectReference {
+	if len(runtimeResource.Spec.ImagePullSecrets) == 0 {
+		return nil
+	}
+
+	references := make(
+		[]corev1.LocalObjectReference,
+		0,
+		len(runtimeResource.Spec.ImagePullSecrets),
+	)
+
+	for _, reference := range runtimeResource.Spec.ImagePullSecrets {
+		references = append(
+			references,
+			corev1.LocalObjectReference{Name: reference.Name},
+		)
+	}
+
+	return references
+}
+
+// runtimeConfigData builds the environment configuration projected through the
+// managed ConfigMap.
+func runtimeConfigData(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) map[string]string {
+	data := map[string]string{
+		envEnvironment:  defaultRuntimeEnvironment,
+		envRuntimeHost:  defaultRuntimeHost,
+		envRuntimePort:  strconv.Itoa(int(runtimeHTTPPort)),
+		envProviderName: string(runtimeResource.Spec.Provider.Type),
+	}
+
+	if runtimeResource.Spec.Provider.BaseURL != nil {
+		data[envProviderBaseURL] = *runtimeResource.Spec.Provider.BaseURL
+	}
+
+	if runtimeResource.Spec.Runtime == nil {
+		return data
+	}
+
+	if timeout := runtimeResource.Spec.Runtime.ProviderRequestTimeoutSeconds; timeout != nil {
+		data[envProviderRequestSeconds] = strconv.Itoa(int(*timeout))
+	}
+
+	if timeout := runtimeResource.Spec.Runtime.StreamIdleTimeoutSeconds; timeout != nil {
+		data[envProviderStreamIdle] = strconv.Itoa(int(*timeout))
+	}
+
+	if timeout := runtimeResource.Spec.Runtime.ShutdownDrainTimeoutSeconds; timeout != nil {
+		data[envRuntimeShutdownSeconds] = strconv.Itoa(int(*timeout))
+	}
+
+	return data
+}
+
+// buildConfigMap constructs the desired runtime ConfigMap.
+func buildConfigMap(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runtimeResource.Name,
+			Namespace: runtimeResource.Namespace,
+			Labels:    runtimeLabels(runtimeResource),
+		},
+		Data: runtimeConfigData(runtimeResource),
+	}
+}
+
+// buildServiceAccount constructs the dedicated runtime ServiceAccount.
+func buildServiceAccount(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) *corev1.ServiceAccount {
+	return &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runtimeResource.Name,
+			Namespace: runtimeResource.Namespace,
+			Labels:    runtimeLabels(runtimeResource),
+		},
+		AutomountServiceAccountToken: ptr.To(false),
+		ImagePullSecrets:             imagePullSecrets(runtimeResource),
+	}
+}
+
+// buildService constructs the runtime Service.
+func buildService(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) *corev1.Service {
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runtimeResource.Name,
+			Namespace: runtimeResource.Namespace,
+			Labels:    runtimeLabels(runtimeResource),
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     desiredServiceType(runtimeResource),
+			Selector: runtimeSelectorLabels(runtimeResource),
+			Ports: []corev1.ServicePort{
+				{
+					Name:       runtimeHTTPPortName,
+					Protocol:   corev1.ProtocolTCP,
+					Port:       desiredServicePort(runtimeResource),
+					TargetPort: intstr.FromString(runtimeHTTPPortName),
+				},
+			},
+		},
+	}
+}
+
+// providerCredentialEnv returns the provider credential environment variable
+// when the custom resource references a Secret key.
+func providerCredentialEnv(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) []corev1.EnvVar {
+	secretReference := runtimeResource.Spec.Provider.CredentialsSecretRef
+	if secretReference == nil {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name: envProviderAPIKey,
+			ValueFrom: &corev1.EnvVarSource{
+				SecretKeyRef: &corev1.SecretKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: secretReference.Name,
+					},
+					Key: secretReference.Key,
+				},
+			},
+		},
+	}
+}
+
+// buildDeployment constructs the desired runtime Deployment.
+func buildDeployment(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) *appsv1.Deployment {
+	labels := runtimeLabels(runtimeResource)
+	selectorLabels := runtimeSelectorLabels(runtimeResource)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runtimeResource.Name,
+			Namespace: runtimeResource.Namespace,
+			Labels:    labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptr.To(desiredReplicas(runtimeResource)),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: selectorLabels,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+				Spec: corev1.PodSpec{
+					ServiceAccountName:           runtimeResource.Name,
+					AutomountServiceAccountToken: ptr.To(false),
+					EnableServiceLinks:           ptr.To(false),
+					ImagePullSecrets:             imagePullSecrets(runtimeResource),
+					Containers: []corev1.Container{
+						{
+							Name:            runtimeContainerName,
+							Image:           runtimeImage(runtimeResource.Spec.Image),
+							ImagePullPolicy: runtimeResource.Spec.Image.PullPolicy,
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          runtimeHTTPPortName,
+									ContainerPort: runtimeHTTPPort,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							EnvFrom: []corev1.EnvFromSource{
+								{
+									ConfigMapRef: &corev1.ConfigMapEnvSource{
+										LocalObjectReference: corev1.LocalObjectReference{
+											Name: runtimeResource.Name,
+										},
+									},
+								},
+							},
+							Env:       providerCredentialEnv(runtimeResource),
+							Resources: *runtimeResource.Spec.Resources.DeepCopy(),
+						},
+					},
+				},
+			},
+		},
+	}
+}

--- a/internal/controller/runtime_resources_test.go
+++ b/internal/controller/runtime_resources_test.go
@@ -1,0 +1,360 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	runtimev1alpha1 "github.com/trussium/trussium-operator/api/v1alpha1"
+)
+
+func TestRuntimeImageWithTag(t *testing.T) {
+	t.Parallel()
+
+	tag := testRuntimeTag
+
+	image := runtimeImage(runtimev1alpha1.RuntimeImageSpec{
+		Repository: testRuntimeRepository,
+		Tag:        &tag,
+	})
+
+	expected := testRuntimeImage
+	if image != expected {
+		t.Fatalf("expected image %q, received %q", expected, image)
+	}
+}
+
+func TestRuntimeImageWithDigest(t *testing.T) {
+	t.Parallel()
+
+	digest := "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+	image := runtimeImage(runtimev1alpha1.RuntimeImageSpec{
+		Repository: testRuntimeRepository,
+		Digest:     &digest,
+	})
+
+	expected := testRuntimeRepository + "@" + digest
+	if image != expected {
+		t.Fatalf("expected image %q, received %q", expected, image)
+	}
+}
+
+func TestRuntimeConfigData(t *testing.T) {
+	t.Parallel()
+
+	baseURL := "http://ollama.ollama.svc.cluster.local:11434/v1"
+	providerTimeout := int32(75)
+	streamTimeout := int32(40)
+	shutdownTimeout := int32(50)
+
+	runtimeResource := newTestRuntime()
+	runtimeResource.Spec.Provider.BaseURL = &baseURL
+	runtimeResource.Spec.Runtime = &runtimev1alpha1.RuntimeSettingsSpec{
+		ProviderRequestTimeoutSeconds: &providerTimeout,
+		StreamIdleTimeoutSeconds:      &streamTimeout,
+		ShutdownDrainTimeoutSeconds:   &shutdownTimeout,
+	}
+
+	actual := runtimeConfigData(runtimeResource)
+
+	expected := map[string]string{
+		envEnvironment:            "production",
+		envRuntimeHost:            "0.0.0.0",
+		envRuntimePort:            "9000",
+		envProviderName:           "ollama",
+		envProviderBaseURL:        baseURL,
+		envProviderRequestSeconds: "75",
+		envProviderStreamIdle:     "40",
+		envRuntimeShutdownSeconds: "50",
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf(
+			"unexpected ConfigMap data\nexpected: %#v\nactual: %#v",
+			expected,
+			actual,
+		)
+	}
+}
+
+func TestRuntimeConfigDataOmitsOptionalSettings(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	runtimeResource.Spec.Provider.BaseURL = nil
+	runtimeResource.Spec.Runtime = nil
+
+	actual := runtimeConfigData(runtimeResource)
+
+	if _, exists := actual[envProviderBaseURL]; exists {
+		t.Fatal("provider base URL should be omitted")
+	}
+
+	if _, exists := actual[envProviderRequestSeconds]; exists {
+		t.Fatal("provider timeout should be omitted")
+	}
+
+	if _, exists := actual[envProviderStreamIdle]; exists {
+		t.Fatal("stream-idle timeout should be omitted")
+	}
+
+	if _, exists := actual[envRuntimeShutdownSeconds]; exists {
+		t.Fatal("shutdown timeout should be omitted")
+	}
+}
+
+func TestBuildServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	runtimeResource.Spec.ImagePullSecrets = []runtimev1alpha1.NamedReference{
+		{Name: testImagePullSecret},
+	}
+
+	serviceAccount := buildServiceAccount(runtimeResource)
+
+	if serviceAccount.Name != runtimeResource.Name {
+		t.Fatalf(
+			"expected ServiceAccount name %q, received %q",
+			runtimeResource.Name,
+			serviceAccount.Name,
+		)
+	}
+
+	if serviceAccount.AutomountServiceAccountToken == nil ||
+		*serviceAccount.AutomountServiceAccountToken {
+		t.Fatal("expected ServiceAccount token automount to be disabled")
+	}
+
+	expectedSecrets := []corev1.LocalObjectReference{
+		{Name: testImagePullSecret},
+	}
+
+	if !reflect.DeepEqual(
+		expectedSecrets,
+		serviceAccount.ImagePullSecrets,
+	) {
+		t.Fatalf(
+			"unexpected image-pull Secrets: %#v",
+			serviceAccount.ImagePullSecrets,
+		)
+	}
+}
+
+func TestBuildService(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	runtimeResource.Spec.Service.Type = corev1.ServiceTypeLoadBalancer
+	runtimeResource.Spec.Service.Port = 9443
+
+	service := buildService(runtimeResource)
+
+	if service.Spec.Type != corev1.ServiceTypeLoadBalancer {
+		t.Fatalf(
+			"expected LoadBalancer Service, received %q",
+			service.Spec.Type,
+		)
+	}
+
+	if len(service.Spec.Ports) != 1 {
+		t.Fatalf(
+			"expected one Service port, received %d",
+			len(service.Spec.Ports),
+		)
+	}
+
+	port := service.Spec.Ports[0]
+	if port.Port != 9443 {
+		t.Fatalf("expected Service port 9443, received %d", port.Port)
+	}
+
+	if port.TargetPort.StrVal != runtimeHTTPPortName {
+		t.Fatalf(
+			"expected target port %q, received %q",
+			runtimeHTTPPortName,
+			port.TargetPort.StrVal,
+		)
+	}
+}
+
+func TestBuildDeployment(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	runtimeResource.Spec.ImagePullSecrets = []runtimev1alpha1.NamedReference{
+		{Name: testImagePullSecret},
+	}
+	runtimeResource.Spec.Provider.CredentialsSecretRef =
+		&runtimev1alpha1.SecretKeyReference{
+			Name: "ollama-credentials",
+			Key:  "api-key",
+		}
+	runtimeResource.Spec.Resources = corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("250m"),
+			corev1.ResourceMemory: resource.MustParse("256Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("1"),
+			corev1.ResourceMemory: resource.MustParse("1Gi"),
+		},
+	}
+
+	deployment := buildDeployment(runtimeResource)
+
+	if deployment.Spec.Replicas == nil ||
+		*deployment.Spec.Replicas != 2 {
+		t.Fatalf(
+			"expected two replicas, received %#v",
+			deployment.Spec.Replicas,
+		)
+	}
+
+	if deployment.Spec.Template.Spec.ServiceAccountName !=
+		runtimeResource.Name {
+		t.Fatalf(
+			"expected ServiceAccount %q, received %q",
+			runtimeResource.Name,
+			deployment.Spec.Template.Spec.ServiceAccountName,
+		)
+	}
+
+	if deployment.Spec.Template.Spec.EnableServiceLinks == nil ||
+		*deployment.Spec.Template.Spec.EnableServiceLinks {
+		t.Fatal("expected Service links to be disabled")
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf(
+			"expected one container, received %d",
+			len(deployment.Spec.Template.Spec.Containers),
+		)
+	}
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	expectedImage := testRuntimeImage
+	if container.Image != expectedImage {
+		t.Fatalf(
+			"expected image %q, received %q",
+			expectedImage,
+			container.Image,
+		)
+	}
+
+	if len(container.EnvFrom) != 1 ||
+		container.EnvFrom[0].ConfigMapRef == nil ||
+		container.EnvFrom[0].ConfigMapRef.Name != runtimeResource.Name {
+		t.Fatalf(
+			"expected ConfigMap reference %q, received %#v",
+			runtimeResource.Name,
+			container.EnvFrom,
+		)
+	}
+
+	if len(container.Env) != 1 {
+		t.Fatalf(
+			"expected one credential environment variable, received %d",
+			len(container.Env),
+		)
+	}
+
+	credential := container.Env[0]
+	if credential.Name != envProviderAPIKey {
+		t.Fatalf(
+			"expected credential environment variable %q, received %q",
+			envProviderAPIKey,
+			credential.Name,
+		)
+	}
+
+	if credential.ValueFrom == nil ||
+		credential.ValueFrom.SecretKeyRef == nil {
+		t.Fatal("expected provider Secret key reference")
+	}
+
+	if credential.ValueFrom.SecretKeyRef.Name != "ollama-credentials" ||
+		credential.ValueFrom.SecretKeyRef.Key != "api-key" {
+		t.Fatalf(
+			"unexpected Secret key reference: %#v",
+			credential.ValueFrom.SecretKeyRef,
+		)
+	}
+
+	if !reflect.DeepEqual(
+		runtimeResource.Spec.Resources,
+		container.Resources,
+	) {
+		t.Fatalf(
+			"unexpected resource requirements: %#v",
+			container.Resources,
+		)
+	}
+}
+
+func TestBuildDeploymentWithoutProviderCredentials(t *testing.T) {
+	t.Parallel()
+
+	deployment := buildDeployment(newTestRuntime())
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	if len(container.Env) != 0 {
+		t.Fatalf(
+			"expected no credential environment variables, received %#v",
+			container.Env,
+		)
+	}
+}
+
+func newTestRuntime() *runtimev1alpha1.TrussiumRuntime {
+	tag := testRuntimeTag
+
+	return &runtimev1alpha1.TrussiumRuntime{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: runtimev1alpha1.GroupVersion.String(),
+			Kind:       "TrussiumRuntime",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "production",
+			Namespace: testRuntimeNamespace,
+		},
+		Spec: runtimev1alpha1.TrussiumRuntimeSpec{
+			Image: runtimev1alpha1.RuntimeImageSpec{
+				Repository: testRuntimeRepository,
+				Tag:        &tag,
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			Replicas: ptr.To(int32(2)),
+			Provider: runtimev1alpha1.ProviderSpec{
+				Type:  runtimev1alpha1.ProviderTypeOllama,
+				Model: "llama3.2",
+			},
+			Service: runtimev1alpha1.RuntimeServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Port: 9000,
+			},
+		},
+	}
+}

--- a/internal/controller/test_constants_test.go
+++ b/internal/controller/test_constants_test.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+const (
+	testRuntimeRepository = "ghcr.io/trussium/trussium"
+	testRuntimeTag        = "0.23.0"
+	testRuntimeImage      = testRuntimeRepository + ":" + testRuntimeTag
+	testRuntimeNamespace  = runtimeContainerName
+	testImagePullSecret   = "ghcr-credentials"
+)

--- a/internal/controller/trussiumruntime_controller.go
+++ b/internal/controller/trussiumruntime_controller.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	runtimev1alpha1 "github.com/trussium/trussium-operator/api/v1alpha1"
+)
+
+// TrussiumRuntimeReconciler reconciles a TrussiumRuntime resource.
+type TrussiumRuntimeReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+}
+
+// +kubebuilder:rbac:groups=runtime.trussium.io,resources=trussiumruntimes,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps;serviceaccounts;services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
+
+// Reconcile ensures that the Kubernetes resources owned by a TrussiumRuntime
+// match the desired custom-resource specification.
+func (r *TrussiumRuntimeReconciler) Reconcile(
+	ctx context.Context,
+	req ctrl.Request,
+) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	var runtimeResource runtimev1alpha1.TrussiumRuntime
+	if err := r.Get(ctx, req.NamespacedName, &runtimeResource); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+
+	if !runtimeResource.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, nil
+	}
+
+	if err := r.reconcileConfigMap(ctx, &runtimeResource); err != nil {
+		return ctrl.Result{}, fmt.Errorf(
+			"reconcile ConfigMap %s/%s: %w",
+			runtimeResource.Namespace,
+			runtimeResource.Name,
+			err,
+		)
+	}
+
+	if err := r.reconcileServiceAccount(ctx, &runtimeResource); err != nil {
+		return ctrl.Result{}, fmt.Errorf(
+			"reconcile ServiceAccount %s/%s: %w",
+			runtimeResource.Namespace,
+			runtimeResource.Name,
+			err,
+		)
+	}
+
+	if err := r.reconcileService(ctx, &runtimeResource); err != nil {
+		return ctrl.Result{}, fmt.Errorf(
+			"reconcile Service %s/%s: %w",
+			runtimeResource.Namespace,
+			runtimeResource.Name,
+			err,
+		)
+	}
+
+	if err := r.reconcileDeployment(ctx, &runtimeResource); err != nil {
+		return ctrl.Result{}, fmt.Errorf(
+			"reconcile Deployment %s/%s: %w",
+			runtimeResource.Namespace,
+			runtimeResource.Name,
+			err,
+		)
+	}
+
+	logger.Info(
+		"reconciled TrussiumRuntime resources",
+		"name",
+		runtimeResource.Name,
+		"namespace",
+		runtimeResource.Namespace,
+	)
+
+	return ctrl.Result{}, nil
+}
+
+func (r *TrussiumRuntimeReconciler) reconcileConfigMap(
+	ctx context.Context,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) error {
+	desired := buildConfigMap(runtimeResource)
+
+	current := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(
+		ctx,
+		r.Client,
+		current,
+		func() error {
+			current.Labels = desired.Labels
+			current.Data = desired.Data
+
+			return controllerutil.SetControllerReference(
+				runtimeResource,
+				current,
+				r.Scheme,
+			)
+		},
+	)
+
+	return err
+}
+
+func (r *TrussiumRuntimeReconciler) reconcileServiceAccount(
+	ctx context.Context,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) error {
+	desired := buildServiceAccount(runtimeResource)
+
+	current := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(
+		ctx,
+		r.Client,
+		current,
+		func() error {
+			current.Labels = desired.Labels
+			current.AutomountServiceAccountToken =
+				desired.AutomountServiceAccountToken
+			current.ImagePullSecrets = desired.ImagePullSecrets
+
+			return controllerutil.SetControllerReference(
+				runtimeResource,
+				current,
+				r.Scheme,
+			)
+		},
+	)
+
+	return err
+}
+
+func (r *TrussiumRuntimeReconciler) reconcileService(
+	ctx context.Context,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) error {
+	desired := buildService(runtimeResource)
+
+	current := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(
+		ctx,
+		r.Client,
+		current,
+		func() error {
+			current.Labels = desired.Labels
+			current.Spec.Type = desired.Spec.Type
+			current.Spec.Selector = desired.Spec.Selector
+			current.Spec.Ports = desired.Spec.Ports
+
+			return controllerutil.SetControllerReference(
+				runtimeResource,
+				current,
+				r.Scheme,
+			)
+		},
+	)
+
+	return err
+}
+
+func (r *TrussiumRuntimeReconciler) reconcileDeployment(
+	ctx context.Context,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) error {
+	desired := buildDeployment(runtimeResource)
+
+	current := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      desired.Name,
+			Namespace: desired.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(
+		ctx,
+		r.Client,
+		current,
+		func() error {
+			current.Labels = desired.Labels
+			current.Spec = desired.Spec
+
+			return controllerutil.SetControllerReference(
+				runtimeResource,
+				current,
+				r.Scheme,
+			)
+		},
+	)
+
+	return err
+}
+
+// SetupWithManager configures watches for TrussiumRuntime and its owned
+// Kubernetes resources.
+func (r *TrussiumRuntimeReconciler) SetupWithManager(
+	mgr ctrl.Manager,
+) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&runtimev1alpha1.TrussiumRuntime{}).
+		Owns(&corev1.ConfigMap{}).
+		Owns(&corev1.ServiceAccount{}).
+		Owns(&corev1.Service{}).
+		Owns(&appsv1.Deployment{}).
+		Named("trussiumruntime").
+		Complete(r)
+}

--- a/internal/controller/trussiumruntime_controller_test.go
+++ b/internal/controller/trussiumruntime_controller_test.go
@@ -1,0 +1,321 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	runtimev1alpha1 "github.com/trussium/trussium-operator/api/v1alpha1"
+)
+
+func TestReconcileCreatesOwnedRuntimeResources(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	runtimeResource := newTestRuntime()
+	runtimeResource.UID = types.UID("runtime-uid")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(runtimeResource).
+		Build()
+
+	reconciler := TrussiumRuntimeReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      runtimeResource.Name,
+			Namespace: runtimeResource.Namespace,
+		},
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("reconcile TrussiumRuntime: %v", err)
+	}
+
+	assertManagedResourceExists(
+		t,
+		ctx,
+		fakeClient,
+		runtimeResource,
+		&corev1.ConfigMap{},
+	)
+
+	assertManagedResourceExists(
+		t,
+		ctx,
+		fakeClient,
+		runtimeResource,
+		&corev1.ServiceAccount{},
+	)
+
+	assertManagedResourceExists(
+		t,
+		ctx,
+		fakeClient,
+		runtimeResource,
+		&corev1.Service{},
+	)
+
+	assertManagedResourceExists(
+		t,
+		ctx,
+		fakeClient,
+		runtimeResource,
+		&appsv1.Deployment{},
+	)
+}
+
+func TestReconcileCorrectsDrift(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	runtimeResource := newTestRuntime()
+	runtimeResource.UID = types.UID("runtime-uid")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(runtimeResource).
+		Build()
+
+	reconciler := TrussiumRuntimeReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(runtimeResource),
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("initial reconciliation: %v", err)
+	}
+
+	var deployment appsv1.Deployment
+	if err := fakeClient.Get(
+		ctx,
+		request.NamespacedName,
+		&deployment,
+	); err != nil {
+		t.Fatalf("get managed Deployment: %v", err)
+	}
+
+	deployment.Spec.Replicas = nil
+	deployment.Spec.Template.Spec.Containers[0].Image = "invalid/image:drift"
+
+	if err := fakeClient.Update(ctx, &deployment); err != nil {
+		t.Fatalf("introduce Deployment drift: %v", err)
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("reconcile drifted Deployment: %v", err)
+	}
+
+	if err := fakeClient.Get(
+		ctx,
+		request.NamespacedName,
+		&deployment,
+	); err != nil {
+		t.Fatalf("get corrected Deployment: %v", err)
+	}
+
+	if deployment.Spec.Replicas == nil ||
+		*deployment.Spec.Replicas != 2 {
+		t.Fatalf(
+			"expected two replicas after drift correction, received %#v",
+			deployment.Spec.Replicas,
+		)
+	}
+
+	expectedImage := testRuntimeImage
+	actualImage := deployment.Spec.Template.Spec.Containers[0].Image
+
+	if actualImage != expectedImage {
+		t.Fatalf(
+			"expected image %q after drift correction, received %q",
+			expectedImage,
+			actualImage,
+		)
+	}
+}
+
+func TestReconcileRecreatesDeletedManagedResource(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	runtimeResource := newTestRuntime()
+	runtimeResource.UID = types.UID("runtime-uid")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(runtimeResource).
+		Build()
+
+	reconciler := TrussiumRuntimeReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(runtimeResource),
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("initial reconciliation: %v", err)
+	}
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      runtimeResource.Name,
+			Namespace: runtimeResource.Namespace,
+		},
+	}
+
+	if err := fakeClient.Delete(ctx, service); err != nil {
+		t.Fatalf("delete managed Service: %v", err)
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("reconcile after Service deletion: %v", err)
+	}
+
+	var recreated corev1.Service
+	if err := fakeClient.Get(
+		ctx,
+		request.NamespacedName,
+		&recreated,
+	); err != nil {
+		t.Fatalf("get recreated Service: %v", err)
+	}
+
+	if !metav1.IsControlledBy(&recreated, runtimeResource) {
+		t.Fatal("recreated Service is missing controller owner reference")
+	}
+}
+
+func TestReconcileIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+	runtimeResource := newTestRuntime()
+	runtimeResource.UID = types.UID("runtime-uid")
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(runtimeResource).
+		Build()
+
+	reconciler := TrussiumRuntimeReconciler{
+		Client: fakeClient,
+		Scheme: scheme,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(runtimeResource),
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("first reconciliation: %v", err)
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("second reconciliation: %v", err)
+	}
+}
+
+func TestReconcileIgnoresMissingRuntime(t *testing.T) {
+	ctx := context.Background()
+	scheme := newTestScheme(t)
+
+	reconciler := TrussiumRuntimeReconciler{
+		Client: fake.NewClientBuilder().
+			WithScheme(scheme).
+			Build(),
+		Scheme: scheme,
+	}
+
+	request := ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "missing",
+			Namespace: testRuntimeNamespace,
+		},
+	}
+
+	if _, err := reconciler.Reconcile(ctx, request); err != nil {
+		t.Fatalf("expected missing runtime to be ignored: %v", err)
+	}
+}
+
+func newTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register core Kubernetes API: %v", err)
+	}
+
+	if err := appsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register apps Kubernetes API: %v", err)
+	}
+
+	if err := runtimev1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("register TrussiumRuntime API: %v", err)
+	}
+
+	return scheme
+}
+
+func assertManagedResourceExists(
+	t *testing.T,
+	ctx context.Context,
+	kubernetesClient client.Client,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	object client.Object,
+) {
+	t.Helper()
+
+	key := client.ObjectKeyFromObject(runtimeResource)
+
+	if err := kubernetesClient.Get(ctx, key, object); err != nil {
+		t.Fatalf("get managed %T: %v", object, err)
+	}
+
+	if !metav1.IsControlledBy(object, runtimeResource) {
+		t.Fatalf(
+			"managed %T is missing controller owner reference",
+			object,
+		)
+	}
+
+	if object.GetLabels()["app.kubernetes.io/managed-by"] !=
+		"trussium-operator" {
+		t.Fatalf(
+			"managed %T is missing operator label",
+			object,
+		)
+	}
+}


### PR DESCRIPTION
Closes #10

## Summary

Implements the first `TrussiumRuntime` controller and reconciles the core Kubernetes resources required to run a Trussium instance.

For each namespaced `TrussiumRuntime`, the controller now manages:

- ConfigMap
- ServiceAccount
- Service
- Deployment

The implementation uses deterministic names, stable labels, controller owner references, create-or-update reconciliation, drift correction, and owned-resource watches.

Status updates and Kubernetes Events remain intentionally out of scope.

## Motivation

The `TrussiumRuntime v1alpha1` API defines the desired runtime image, provider configuration, credential references, runtime settings, replicas, Service configuration, image-pull Secrets, and resource requirements.

This pull request translates that public desired-state contract into Kubernetes-native resources while preserving the boundary between the Go operator and the released Python Trussium runtime.

## Changes

### Controller

- Added the `TrussiumRuntime` reconciler.
- Registered the controller with the manager.
- Added watches for `TrussiumRuntime`.
- Added watches for owned ConfigMaps.
- Added watches for owned ServiceAccounts.
- Added watches for owned Services.
- Added watches for owned Deployments.
- Ignored missing and deleting custom resources.
- Avoided periodic polling and explicit requeueing.

### ConfigMap

- Added non-secret runtime configuration projection.
- Added runtime environment, host, and port configuration.
- Added provider type and optional provider base URL.
- Added optional provider request timeout.
- Added optional stream-idle timeout.
- Added optional graceful-shutdown timeout.
- Preserved runtime-owned defaults by omitting absent overrides.

### ServiceAccount

- Added one dedicated ServiceAccount per runtime.
- Disabled automatic Kubernetes API token mounting.
- Added image-pull Secret references.
- Added stable labels and controller ownership.

### Service

- Added configurable Service type.
- Added configurable Service port.
- Routed traffic to the named runtime `http` port.
- Added stable runtime selectors.
- Preserved Kubernetes-assigned Service fields.

### Deployment

- Added image tag and digest rendering.
- Added configurable replica projection.
- Added the dedicated ServiceAccount.
- Disabled ServiceAccount token mounting.
- Disabled Kubernetes Service links.
- Exposed runtime container port `9000`.
- Loaded non-secret settings from the managed ConfigMap.
- Projected provider credentials through a Secret key reference.
- Added image-pull Secret projection.
- Added resource request and limit projection.

### Ownership and Drift

- Added deterministic managed-resource names.
- Added stable application labels.
- Added controller owner references.
- Added create-or-update reconciliation.
- Added deleted-resource recreation.
- Added managed-field drift correction.
- Relied on Kubernetes garbage collection rather than a finalizer.

### RBAC

- Added read-only access for `TrussiumRuntime`.
- Added management permissions for ConfigMaps.
- Added management permissions for ServiceAccounts.
- Added management permissions for Services.
- Added management permissions for Deployments.
- Added no Secret read permissions.
- Added no status-update permissions.

### Testing

- Added runtime image tag tests.
- Added runtime image digest tests.
- Added ConfigMap projection tests.
- Added optional-setting omission tests.
- Added ServiceAccount builder tests.
- Added Service builder tests.
- Added Deployment builder tests.
- Added provider credential projection tests.
- Added owner-reference tests.
- Added initial reconciliation tests.
- Added drift-correction tests.
- Added managed-resource recreation tests.
- Added idempotent reconciliation tests.
- Added missing-resource reconciliation tests.

### Documentation

- Added core reconciliation documentation.
- Added ADR 0004 covering owner references and managed-resource ownership.
- Updated the ADR index.
- Updated the README.
- Marked Milestone O3 as completed.
- Identified runtime status and Kubernetes Events as the next milestone.

## Runtime Configuration

The managed ConfigMap projects:

    TRUSSIUM_ENVIRONMENT
    TRUSSIUM_RUNTIME__HOST
    TRUSSIUM_RUNTIME__PORT
    TRUSSIUM_PROVIDER__NAME
    TRUSSIUM_PROVIDER__BASE_URL
    TRUSSIUM_TIMEOUTS__PROVIDER_REQUEST_SECONDS
    TRUSSIUM_TIMEOUTS__STREAM_IDLE_SECONDS
    TRUSSIUM_RUNTIME__GRACEFUL_SHUTDOWN_SECONDS

Optional configuration is omitted when not declared.

Provider credentials are projected directly from the referenced Secret key as:

    TRUSSIUM_PROVIDER__API_KEY

The operator does not read or copy Secret values.

## Scope Boundary

This pull request does not add:

- `TrussiumRuntime.status` updates
- Kubernetes Events
- Runtime readiness conditions
- Secret existence validation
- Deployment rollout monitoring
- Startup, readiness, or liveness probes
- Production workload security contexts
- PodDisruptionBudget
- Topology spreading
- HorizontalPodAutoscaler
- NetworkPolicy
- Configuration checksum rollout annotations
- Finalizers
- Admission webhooks
- Conversion webhooks
- Helm packaging
- Operator image publication

## Validation

The following commands pass:

    go mod tidy
    go mod verify

    make generate
    make manifests
    make fmt
    make vet
    make test
    make lint

    go test ./internal/controller -v
    go build ./cmd/...

Generated artifacts remain stable:

    git add -A

    make generate
    make manifests
    make fmt

    git diff --exit-code
    git diff --cached --check

The tests verify:

- Image tag and digest rendering
- ConfigMap configuration projection
- Optional configuration omission
- ServiceAccount construction
- Service construction
- Deployment construction
- Provider credential Secret references
- Resource ownership
- Initial reconciliation
- Drift correction
- Deleted-resource recreation
- Idempotent reconciliation
- Missing custom-resource handling

## Security

- Provider credentials remain in Kubernetes Secrets.
- Secret values are never read by the controller.
- Secret values are never copied to ConfigMaps.
- Secret values are never logged.
- Runtime ServiceAccount token mounting is disabled.
- Pod Service links are disabled.
- Managed resources are restricted to the custom-resource namespace.
- No cross-namespace references are introduced.
- No Secret read RBAC is introduced.
- No finalizer is introduced.
- No status-update RBAC is introduced.

## Compatibility

- **Operator compatibility:** Introduces the first runtime controller.
- **Trussium runtime compatibility:** Projects the documented runtime configuration contract.
- **Kubernetes compatibility:** Uses namespaced owner references and standard controller-runtime reconciliation.
- **CRD/API compatibility:** Does not change the existing `v1alpha1` schema.

## Checklist

- [x] The change is scoped to the linked issue.
- [x] The Go module remains `github.com/trussium/trussium-operator`.
- [x] The existing `v1alpha1` API remains compatible.
- [x] The controller is registered with the manager.
- [x] Managed resources have controller owner references.
- [x] Deleted managed resources are recreated.
- [x] Managed drift is corrected.
- [x] Repeated reconciliation is idempotent.
- [x] Provider credentials use Secret key references.
- [x] Secret contents are never read.
- [x] ServiceAccount token mounting is disabled.
- [x] No finalizer is introduced.
- [x] No status logic is introduced.
- [x] No Kubernetes Events are introduced.
- [x] Generated RBAC is least privilege.
- [x] Unit tests pass.
- [x] Reconciliation tests pass.
- [x] Go vet passes.
- [x] Lint passes.
- [x] The manager package builds.
- [x] Generated artifacts are stable.
- [x] Local `bin` tooling is excluded from source control.
- [x] Documentation is complete.
- [x] The pull request title follows Conventional Commits.