### PR TITLE
feat(controller): add runtime upgrade lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,31 @@ Run:
     make test
     make lint
 
+## Runtime Upgrades
+
+The operator observes runtime image transitions through Kubernetes Deployment
+status.
+
+Upgrade status reports:
+
+- Desired runtime image
+- Deployment-configured runtime image
+- Last successfully rolled-out image
+- Upgrade progress
+- Upgrade completion
+- Upgrade failure
+
+Runtime configuration changes also trigger Deployment revisions through a
+deterministic Pod-template checksum.
+
+The operator does not automatically roll back failed upgrades and does not
+require Pod or ReplicaSet permissions.
+
+See:
+
+- [docs/UPGRADES.md](docs/UPGRADES.md)
+- [docs/COMPATIBILITY.md](docs/COMPATIBILITY.md)
+
 ## Roadmap
 
 The public operator roadmap is maintained in [ROADMAP.md](ROADMAP.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,36 +12,31 @@ through GitHub Issues.
 
 ## Current Focus
 
-The production Kubernetes deployment contract for `TrussiumRuntime` workloads
-has been implemented.
+The runtime upgrade lifecycle and compatibility contract have been implemented.
 
-The operator now manages production-oriented runtime Deployments with:
+The operator now provides:
 
-- Startup, liveness, and readiness probes
-- Numeric non-root execution
-- `RuntimeDefault` seccomp
-- Read-only root filesystem
-- Disabled privilege escalation
-- Dropped Linux capabilities
-- Graceful shutdown-aware termination timing
-- Zero-unavailable rolling updates
-- Limited Deployment revision history
-- Hostname topology spreading
-- Managed PodDisruptionBudgets
-- Additional Pod labels and annotations
-- Node selectors
-- Tolerations
-- Affinity configuration
+- Desired runtime image reporting
+- Current Deployment image reporting
+- Last successful runtime image tracking
+- Explicit runtime image upgrade detection
+- `Upgrading` condition
+- Upgrade progress reporting
+- Upgrade completion reporting
+- Upgrade failure reporting
+- Deployment rollout completion detection
+- Deployment progress deadline handling
+- Replica failure handling
+- Scale-to-zero upgrade semantics
+- Deterministic runtime configuration checksums
+- Configuration-triggered Deployment rollouts
+- Runtime upgrade lifecycle Events
+- Pre-release operator/runtime compatibility documentation
 
-The operator continues to preserve its existing security boundaries:
+Upgrade observation remains Kubernetes-native and requires no direct Pod or
+ReplicaSet permissions.
 
-- No direct Pod permissions
-- No Secret mutation permissions
-- No arbitrary PodSpec exposure
-- No privileged runtime configuration
-- No ServiceAccount token mounting for runtime workloads
-
-The next priority is the runtime upgrade lifecycle and compatibility contract.
+The next priority is controller integration and end-to-end testing.
 
 ---
 
@@ -325,35 +320,61 @@ security and health invariants remain operator-controlled.
 
 ## Milestone O6 — Upgrade Lifecycle
 
-**Status:** 🗓 Planned
+**Status:** ✅ Completed
 
 Provide predictable runtime configuration and image upgrades with explicit
 observability and compatibility boundaries.
 
-### Deliverables
+### Delivered
 
-- Explicit desired runtime version reporting
-- Explicit current runtime version reporting
-- Runtime image transition observation
-- Upgrade-in-progress condition
-- Upgrade-complete condition
-- Upgrade-failed condition
-- Stable upgrade condition reasons
-- Upgrade lifecycle Events
-- Deployment rollout monitoring
-- Failed rollout detection
-- Upgrade completion detection
-- Configuration checksum annotations
-- Configuration-triggered rollouts
-- Safe image transition behaviour
-- Manual drift recovery
-- Upgrade documentation
-- Rollback documentation
-- Operator/runtime compatibility documentation
-- Runtime compatibility matrix
+- `status.desiredImage`
+- Existing `status.currentImage` semantics preserved
+- `status.lastSuccessfulImage`
+- Initial successful image establishment
+- Initial Deployment excluded from upgrade classification
+- Tag-based upgrade tracking
+- Digest-based upgrade-compatible lifecycle
+- `Upgrading` condition
+- `NoUpgrade` reason
+- `UpgradeInProgress` reason
+- `UpgradeComplete` reason
+- `UpgradeFailed` reason
+- Upgrade-complete state preservation
+- Deployment generation observation
+- Updated replica observation
+- Total replica observation
+- Ready replica observation
+- Available replica observation
+- Unavailable replica observation
+- Deployment rollout completion detection
+- Progress deadline failure detection
+- Replica failure detection
+- Scale-to-zero image upgrade semantics
+- Failed-upgrade successful-image preservation
+- No automatic rollback
+- Explicit `progressDeadlineSeconds: 600`
+- Deterministic SHA-256 runtime configuration checksum
+- Stable checksum independent of Go map iteration order
+- Operator-owned `runtime.trussium.io/config-checksum` annotation
+- Configuration-triggered Deployment rollouts
+- Secret values excluded from checksums
+- `RuntimeUpgradeStarted` Event
+- `RuntimeUpgradeCompleted` Event
+- `RuntimeUpgradeFailed` Event
+- Initial Deployment upgrade-Event suppression
+- Duplicate upgrade-Event prevention
+- No Pod RBAC
+- No ReplicaSet RBAC
+- No rollout polling
+- Upgrade lifecycle tests
+- Configuration checksum tests
+- Upgrade Event tests
+- Upgrade lifecycle documentation
+- Compatibility documentation
+- Upgrade lifecycle architecture decision record
 
-The upgrade lifecycle will build on Deployment status rather than introducing
-direct Pod reads.
+Compatibility is documented for pre-release development without inventing
+unsupported version guarantees.
 
 ---
 
@@ -499,21 +520,23 @@ Compatibility will be tracked by operator and runtime release:
 
 ## Immediate Priority
 
-The next priority is Milestone O6:
+The next priority is Milestone O7:
 
-1. Define the runtime upgrade lifecycle and compatibility contract.
+1. Validate the operator against Kubernetes API machinery and real clusters.
 
 The next milestone will focus on:
 
-- Explicit desired and current runtime version reporting
-- Upgrade-state conditions
-- Upgrade lifecycle Events
-- Deployment rollout monitoring
-- Rollout failure handling
-- Upgrade completion detection
-- Configuration-triggered rollouts
-- Safe runtime image transitions
-- Operator/runtime compatibility boundaries
-- Upgrade documentation
-- Rollback documentation
-- Compatibility matrix foundations
+- envtest integration
+- CRD installation validation
+- Manager/controller integration
+- Managed-resource lifecycle tests
+- Status integration tests
+- Secret-reference integration tests
+- PodDisruptionBudget integration tests
+- Upgrade lifecycle integration tests
+- Kind-cluster installation
+- Real Deployment rollout validation
+- Runtime readiness validation
+- Configuration-triggered rollout validation
+- Runtime image upgrade validation
+- Garbage-collection validation

--- a/api/v1alpha1/trussiumruntime_types.go
+++ b/api/v1alpha1/trussiumruntime_types.go
@@ -241,30 +241,41 @@ type TrussiumRuntimeSpec struct {
 	Scheduling *SchedulingSpec `json:"scheduling,omitempty"`
 }
 
-// TrussiumRuntimeStatus defines the observed state of a Trussium runtime.
+// TrussiumRuntimeStatus defines the observed state of TrussiumRuntime.
 type TrussiumRuntimeStatus struct {
-	// ObservedGeneration is the most recent resource generation processed by
-	// the controller.
+	// ObservedGeneration is the most recent TrussiumRuntime generation
+	// observed by the controller.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 
-	// ReadyReplicas is the number of runtime replicas currently ready.
+	// ReadyReplicas is the number of ready runtime replicas.
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
 
-	// AvailableReplicas is the number of runtime replicas currently available.
+	// AvailableReplicas is the number of available runtime replicas.
 	// +optional
 	AvailableReplicas int32 `json:"availableReplicas,omitempty"`
 
-	// CurrentImage is the complete runtime image observed by the controller.
+	// DesiredImage is the fully rendered runtime image requested by the
+	// current TrussiumRuntime specification.
+	// +optional
+	DesiredImage string `json:"desiredImage,omitempty"`
+
+	// CurrentImage is the runtime image currently configured on the managed
+	// Deployment.
 	// +optional
 	CurrentImage string `json:"currentImage,omitempty"`
 
-	// Endpoint is the Kubernetes Service endpoint for the runtime.
+	// LastSuccessfulImage is the runtime image whose Deployment rollout most
+	// recently completed successfully.
+	// +optional
+	LastSuccessfulImage string `json:"lastSuccessfulImage,omitempty"`
+
+	// Endpoint is the internal Kubernetes Service endpoint for the runtime.
 	// +optional
 	Endpoint string `json:"endpoint,omitempty"`
 
-	// Conditions describe the current runtime state.
+	// Conditions represent the latest available observations of the runtime.
 	// +optional
 	// +listType=map
 	// +listMapKey=type

--- a/config/crd/bases/runtime.trussium.io_trussiumruntimes.yaml
+++ b/config/crd/bases/runtime.trussium.io_trussiumruntimes.yaml
@@ -1291,12 +1291,13 @@ spec:
             description: Status reports the observed runtime state.
             properties:
               availableReplicas:
-                description: AvailableReplicas is the number of runtime replicas currently
-                  available.
+                description: AvailableReplicas is the number of available runtime
+                  replicas.
                 format: int32
                 type: integer
               conditions:
-                description: Conditions describe the current runtime state.
+                description: Conditions represent the latest available observations
+                  of the runtime.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -1356,21 +1357,32 @@ spec:
                 - type
                 x-kubernetes-list-type: map
               currentImage:
-                description: CurrentImage is the complete runtime image observed by
-                  the controller.
+                description: |-
+                  CurrentImage is the runtime image currently configured on the managed
+                  Deployment.
+                type: string
+              desiredImage:
+                description: |-
+                  DesiredImage is the fully rendered runtime image requested by the
+                  current TrussiumRuntime specification.
                 type: string
               endpoint:
-                description: Endpoint is the Kubernetes Service endpoint for the runtime.
+                description: Endpoint is the internal Kubernetes Service endpoint
+                  for the runtime.
+                type: string
+              lastSuccessfulImage:
+                description: |-
+                  LastSuccessfulImage is the runtime image whose Deployment rollout most
+                  recently completed successfully.
                 type: string
               observedGeneration:
                 description: |-
-                  ObservedGeneration is the most recent resource generation processed by
-                  the controller.
+                  ObservedGeneration is the most recent TrussiumRuntime generation
+                  observed by the controller.
                 format: int64
                 type: integer
               readyReplicas:
-                description: ReadyReplicas is the number of runtime replicas currently
-                  ready.
+                description: ReadyReplicas is the number of ready runtime replicas.
                 format: int32
                 type: integer
             type: object

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -1,0 +1,138 @@
+# Operator and Runtime Compatibility
+
+The Trussium Operator and Trussium runtime are independently maintained
+components with an explicit integration boundary.
+
+The operator manages Kubernetes lifecycle.
+
+The runtime repository remains authoritative for runtime process behaviour,
+provider integrations, runtime APIs, runtime configuration semantics, health
+endpoints, and runtime container releases.
+
+## Canonical Runtime Image
+
+The canonical public runtime image repository is:
+
+    ghcr.io/trussiumhq/trussium
+
+The operator also permits another compatible image repository to be supplied
+through `spec.image.repository`.
+
+## Compatibility Dimensions
+
+Compatibility involves:
+
+- Trussium Operator version
+- Trussium runtime release or immutable image identity
+- Kubernetes API compatibility
+- Runtime configuration contract compatibility
+- Runtime health endpoint compatibility
+- Container security and execution contract compatibility
+
+## Pre-Release Compatibility
+
+The operator is currently pre-release.
+
+A version-specific compatibility guarantee has therefore not yet been
+established.
+
+Current compatibility status:
+
+| Operator version | Runtime versions | Status |
+|---|---|---|
+| Pre-release | Pre-release Trussium runtime releases | Development compatibility |
+
+`Development compatibility` means the repositories are being evolved together
+and validated against their documented integration contracts.
+
+It does not currently imply long-term backward or forward compatibility across
+arbitrary pre-release revisions.
+
+## Runtime Contract Expected by the Operator
+
+The operator currently expects compatible runtime images to support:
+
+- The configured runtime HTTP port
+- `/health/live`
+- `/health/ready`
+- Runtime environment-variable configuration
+- Graceful process shutdown
+- Numeric non-root execution compatible with UID/GID `10001`
+- Read-only root filesystem operation
+
+Runtime configuration semantics remain defined by the Trussium runtime
+repository.
+
+## Image Identity
+
+Upgrade lifecycle tracking operates on the complete rendered image reference.
+
+Supported examples include:
+
+    ghcr.io/trussiumhq/trussium:v0.24.0
+
+and:
+
+    ghcr.io/trussiumhq/trussium@sha256:<digest>
+
+The operator does not currently interpret image tags as semantic versions.
+
+A digest is treated as an immutable image identity.
+
+## Enforcement
+
+The operator currently documents compatibility but does not reject a runtime
+image based on:
+
+- Tag format
+- Semantic version
+- Digest
+- Registry
+- Runtime release metadata
+
+This avoids inventing compatibility guarantees before independent operator
+releases establish a stable versioning contract.
+
+## Future Compatibility Matrix
+
+Once the operator begins independently versioned releases, this document will
+track supported combinations explicitly.
+
+For example:
+
+| Operator version | Minimum runtime | Maximum tested runtime | Status |
+|---|---|---|---|
+| Future release | TBD | TBD | TBD |
+
+Exact ranges will be added only when verified by release and end-to-end
+testing.
+
+## Upgrade Guidance
+
+Before changing a production runtime image:
+
+1. Review the operator release notes.
+2. Review the runtime release notes.
+3. Confirm the combination is documented as supported or tested.
+4. Use immutable image digests where reproducibility is required.
+5. Observe `status.conditions` and `status.lastSuccessfulImage` during rollout.
+
+The operator does not automatically roll back an incompatible or failed
+runtime image.
+
+## Open-Source Boundary
+
+The public operator will continue to support ordinary runtime upgrades and
+compatibility documentation.
+
+Commercial Trussium products may later provide higher-level capabilities such
+as:
+
+- Fleet-wide compatibility reporting
+- Upgrade waves
+- Maintenance windows
+- Approval workflows
+- Cross-cluster rollout policy
+- Enterprise release channels
+
+The public operator remains independently usable without those services.

--- a/docs/CUSTOM_RESOURCE.md
+++ b/docs/CUSTOM_RESOURCE.md
@@ -271,6 +271,42 @@ The v1alpha1 status contract contains:
 | `endpoint` | Runtime Service endpoint |
 | `conditions` | Standard Kubernetes conditions |
 
+### `status.desiredImage`
+
+Fully rendered image requested by the current `spec.image`.
+
+Example:
+
+    ghcr.io/trussiumhq/trussium:v0.24.0
+
+### `status.currentImage`
+
+Image currently configured on the managed Deployment.
+
+### `status.lastSuccessfulImage`
+
+Image whose Deployment rollout most recently completed successfully.
+
+This value remains unchanged while an upgrade is progressing or after an
+upgrade failure.
+
+### `Upgrading` Condition
+
+Upgrade lifecycle is represented through:
+
+    type: Upgrading
+
+Reasons:
+
+| Reason | Status | Meaning |
+|---|---|---|
+| `NoUpgrade` | `False` | No image upgrade is active |
+| `UpgradeInProgress` | `True` | A previously successful image is transitioning |
+| `UpgradeComplete` | `False` | The desired image completed successfully |
+| `UpgradeFailed` | `False` | The requested image rollout failed |
+
+Initial provisioning is not classified as an upgrade.
+
 ## Printer Columns
 
 A future controller-populated resource will be displayed as:

--- a/docs/RECONCILIATION.md
+++ b/docs/RECONCILIATION.md
@@ -214,6 +214,62 @@ The controller does not currently require:
 - Pod reads
 - PodDisruptionBudget management
 
+## Runtime Upgrade Reconciliation
+
+Runtime image transitions use the existing Deployment reconciliation path.
+
+The controller does not create separate upgrade resources.
+
+After reconciling the desired Deployment, the controller observes Deployment
+status and determines whether the rollout is:
+
+- Waiting for the Deployment controller
+- Progressing
+- Complete
+- Failed
+
+Successful rollout advances:
+
+    status.lastSuccessfulImage
+
+Failed rollout preserves the previous successful image.
+
+The controller never automatically rewrites `spec.image`.
+
+### Deployment Progress Deadline
+
+Managed Deployments use:
+
+    progressDeadlineSeconds: 600
+
+This allows stalled rollouts to surface through the standard Deployment
+`Progressing` condition.
+
+### Configuration Rollout Checksum
+
+Managed runtime configuration is represented in the ConfigMap.
+
+The controller calculates a deterministic SHA-256 checksum of that ConfigMap
+data and projects it onto the Pod template:
+
+    runtime.trussium.io/config-checksum
+
+A runtime configuration change therefore modifies the Pod template and causes
+the Deployment controller to create a new revision.
+
+Secret values are never included in checksum calculation.
+
+### Upgrade Observation Boundary
+
+The controller observes only the Deployment.
+
+It does not require:
+
+- Pod reads
+- ReplicaSet reads
+- Periodic rollout polling
+- Runtime HTTP probes from the controller
+
 ## Current Scope Boundary
 
 This reconciliation milestone does not implement:

--- a/docs/STATUS_AND_EVENTS.md
+++ b/docs/STATUS_AND_EVENTS.md
@@ -67,6 +67,7 @@ The controller maintains five conditions:
 - `Available`
 - `Ready`
 - `Degraded`
+- `Upgrading`
 
 Conditions use stable UpperCamelCase reasons and preserve
 `lastTransitionTime` while their status remains unchanged.
@@ -169,6 +170,53 @@ Reasons include:
 `Degraded=False` uses:
 
 - `AsExpected`
+
+## Upgrade Status
+
+Upgrade lifecycle adds:
+
+| Field | Description |
+|---|---|
+| `desiredImage` | Fully rendered image requested by the current specification |
+| `currentImage` | Image currently configured on the managed Deployment |
+| `lastSuccessfulImage` | Image whose rollout most recently completed successfully |
+
+The operator also maintains:
+
+    type: Upgrading
+
+with stable reasons:
+
+- `NoUpgrade`
+- `UpgradeInProgress`
+- `UpgradeComplete`
+- `UpgradeFailed`
+
+Initial Deployment is not treated as an upgrade.
+
+`lastSuccessfulImage` is initialized only after the first successful rollout.
+
+During an image transition, `lastSuccessfulImage` remains on the previous
+successful image until the desired image completes.
+
+Failed upgrades preserve the previous successful image.
+
+### Upgrade Events
+
+Normal:
+
+- `RuntimeUpgradeStarted`
+- `RuntimeUpgradeCompleted`
+
+Warning:
+
+- `RuntimeUpgradeFailed`
+
+Upgrade Events include the previous successful image and desired image where
+applicable.
+
+They are emitted only for lifecycle transitions and are not duplicated during
+unchanged reconciliation.
 
 ## Deployment Observation
 

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -1,0 +1,354 @@
+# Runtime Upgrade Lifecycle
+
+The Trussium Operator provides an explicit lifecycle for runtime image
+transitions managed through `TrussiumRuntime`.
+
+The operator observes Kubernetes Deployment rollout state rather than directly
+reading Pods or ReplicaSets.
+
+## Image State
+
+`TrussiumRuntime.status` distinguishes three image concepts.
+
+### Desired Image
+
+`status.desiredImage` is the fully rendered image requested by the current
+custom-resource specification.
+
+For example:
+
+    ghcr.io/trussiumhq/trussium:v0.24.0
+
+or:
+
+    ghcr.io/trussiumhq/trussium@sha256:<digest>
+
+### Current Image
+
+`status.currentImage` is the image currently configured on the managed
+Deployment.
+
+This preserves the existing status contract established before upgrade
+lifecycle support was introduced.
+
+### Last Successful Image
+
+`status.lastSuccessfulImage` records the image whose Deployment rollout most
+recently completed successfully.
+
+During an upgrade, the desired and configured Deployment image may already be
+the new image while `lastSuccessfulImage` continues to identify the previous
+successful runtime.
+
+Example:
+
+    desiredImage: ghcr.io/trussiumhq/trussium:v0.24.0
+    currentImage: ghcr.io/trussiumhq/trussium:v0.24.0
+    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v0.23.0
+
+After successful rollout completion:
+
+    desiredImage: ghcr.io/trussiumhq/trussium:v0.24.0
+    currentImage: ghcr.io/trussiumhq/trussium:v0.24.0
+    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v0.24.0
+
+## Initial Deployment
+
+The first successful runtime rollout establishes `lastSuccessfulImage`.
+
+Initial deployment is not classified as an upgrade.
+
+Its upgrade condition is:
+
+    type: Upgrading
+    status: "False"
+    reason: NoUpgrade
+
+This prevents initial provisioning from being confused with a transition from
+one previously successful runtime image to another.
+
+## Upgrade Detection
+
+An image transition is considered an upgrade when:
+
+1. `lastSuccessfulImage` is non-empty.
+2. The currently desired image differs from `lastSuccessfulImage`.
+
+A Deployment rollout caused only by configuration, Pod metadata, scheduling, or
+another Pod-template change is not classified as a runtime image upgrade when
+the image remains unchanged.
+
+Both tagged and digest-based image references participate in the same upgrade
+lifecycle.
+
+## Upgrading Condition
+
+The operator maintains one upgrade-specific condition:
+
+    Upgrading
+
+### NoUpgrade
+
+    type: Upgrading
+    status: "False"
+    reason: NoUpgrade
+
+No runtime image transition is active.
+
+### UpgradeInProgress
+
+    type: Upgrading
+    status: "True"
+    reason: UpgradeInProgress
+
+A previously successful runtime image is being replaced by another desired
+image.
+
+### UpgradeComplete
+
+    type: Upgrading
+    status: "False"
+    reason: UpgradeComplete
+
+The new image successfully completed its Deployment rollout.
+
+The completed state is preserved during unchanged reconciliation.
+
+### UpgradeFailed
+
+    type: Upgrading
+    status: "False"
+    reason: UpgradeFailed
+
+The Deployment reported rollout failure while transitioning to the desired
+image.
+
+The previous `lastSuccessfulImage` remains unchanged.
+
+## Deployment Rollout Observation
+
+The operator derives rollout state from the managed Deployment.
+
+It observes:
+
+- Deployment generation
+- Deployment observed generation
+- Desired replicas
+- Total replicas
+- Updated replicas
+- Ready replicas
+- Available replicas
+- Unavailable replicas
+- Deployment Progressing condition
+- Deployment ReplicaFailure condition
+
+The operator does not read Pods or ReplicaSets.
+
+## Rollout Completion
+
+For a runtime with replicas greater than zero, successful rollout requires:
+
+- The Deployment controller has observed the current Deployment generation.
+- Updated replicas equal desired replicas.
+- Total replicas equal desired replicas.
+- Ready replicas equal desired replicas.
+- Available replicas equal desired replicas.
+- Unavailable replicas equal zero.
+
+This prevents the operator from reporting upgrade completion while old
+Deployment replicas are still present.
+
+## Scale to Zero
+
+A runtime with:
+
+    spec.replicas: 0
+
+can still complete an image upgrade.
+
+The Deployment must have observed its latest generation and all replica counts
+must be zero.
+
+No Pod needs to be started merely to establish the desired image state.
+
+## Rollout Failure
+
+The operator recognizes Deployment rollout failures including:
+
+### Progress Deadline Exceeded
+
+    type: Progressing
+    status: "False"
+    reason: ProgressDeadlineExceeded
+
+### Replica Failure
+
+    type: ReplicaFailure
+    status: "True"
+
+During an image upgrade, failure results in:
+
+    Upgrading=False
+    reason=UpgradeFailed
+
+General runtime conditions also reflect the failure:
+
+    Ready=False
+    Degraded=True
+
+The requested image remains unchanged and `lastSuccessfulImage` remains the
+last successfully rolled-out image.
+
+## No Automatic Rollback
+
+The operator does not automatically change `TrussiumRuntimeSpec` or restore a
+previous image after rollout failure.
+
+Rollback remains an explicit user or automation decision.
+
+This preserves the declarative relationship between the custom-resource
+specification and the managed Deployment.
+
+## Progress Deadline
+
+Managed Deployments use:
+
+    progressDeadlineSeconds: 600
+
+This gives Kubernetes an explicit boundary for reporting stalled Deployment
+progress.
+
+The value is operator-managed in the current API version.
+
+## Configuration-Triggered Rollouts
+
+Runtime configuration is projected through a managed ConfigMap and consumed by
+the runtime container using `envFrom`.
+
+Kubernetes does not create a new Deployment revision when only the referenced
+ConfigMap data changes.
+
+The operator therefore adds this Pod-template annotation:
+
+    runtime.trussium.io/config-checksum
+
+The annotation contains a deterministic SHA-256 checksum of the fully rendered
+operator-managed ConfigMap data.
+
+When runtime configuration changes:
+
+1. ConfigMap data changes.
+2. The checksum changes.
+3. The Deployment Pod template changes.
+4. Kubernetes creates a new Deployment revision.
+5. The rollout is observed through normal Deployment status.
+
+## Checksum Security Boundary
+
+The configuration checksum contains only operator-managed ConfigMap data.
+
+It never contains or derives from:
+
+- Secret values
+- Secret contents
+- Secret resource versions
+- Timestamps
+- Random values
+- Kubernetes object resource versions
+
+Provider credentials remain outside the checksum.
+
+Changing the value stored inside an existing Secret therefore does not
+automatically trigger a runtime rollout during this milestone.
+
+Changing a Secret reference in the custom-resource specification changes the
+Pod template normally.
+
+## Upgrade Events
+
+The operator emits transition-based Kubernetes Events.
+
+### RuntimeUpgradeStarted
+
+Normal Event emitted when an existing successfully deployed runtime begins
+transitioning to another desired image.
+
+### RuntimeUpgradeCompleted
+
+Normal Event emitted when the new runtime image successfully completes its
+Deployment rollout.
+
+### RuntimeUpgradeFailed
+
+Warning Event emitted when an active runtime image upgrade fails.
+
+Upgrade Events include the previous successful image and desired image where
+applicable.
+
+They never include Secret values.
+
+Initial runtime deployment does not emit an upgrade-start Event.
+
+Unchanged reconciliation does not emit duplicate upgrade Events.
+
+## Existing Runtime Conditions
+
+Upgrade state complements rather than replaces the existing runtime conditions:
+
+- `ConfigurationValid`
+- `Progressing`
+- `Available`
+- `Ready`
+- `Degraded`
+
+`Upgrading` describes image-transition lifecycle.
+
+The other conditions continue to describe overall runtime health and
+availability.
+
+## Reconciliation Model
+
+Upgrade observation remains event-driven.
+
+The operator watches the owned Deployment, so Deployment status changes enqueue
+reconciliation.
+
+No polling loop or periodic upgrade requeue is required.
+
+Status-only changes on the `TrussiumRuntime` remain filtered from the primary
+watch.
+
+## RBAC Boundary
+
+Upgrade lifecycle support adds no permissions for:
+
+- Pods
+- ReplicaSets
+- Nodes
+- Secret values
+
+Existing Deployment access is sufficient for rollout observation.
+
+## Compatibility
+
+Runtime upgrade tracking does not parse or enforce semantic versions.
+
+Tags and digests are treated as complete image identities.
+
+Compatibility policy is documented separately in
+[COMPATIBILITY.md](COMPATIBILITY.md).
+
+## Current Limitations
+
+This milestone does not provide:
+
+- Automatic rollback
+- Manual rollback API
+- Upgrade waves
+- Maintenance windows
+- Multi-cluster rollout coordination
+- Runtime registry queries
+- Signature verification
+- Semantic-version admission
+- Secret-content-triggered rollouts
+- Direct application health probing by the controller

--- a/docs/adr/0007-observe-upgrades-through-deployment-status.md
+++ b/docs/adr/0007-observe-upgrades-through-deployment-status.md
@@ -1,0 +1,215 @@
+# ADR 0007 — Observe Runtime Upgrades Through Deployment Status
+
+- Status: Accepted
+- Date: August 2026
+
+## Context
+
+The Trussium Operator reconciles runtime image changes through a Kubernetes
+Deployment.
+
+Before this decision, image changes were applied correctly but were not modeled
+as an explicit runtime upgrade lifecycle.
+
+Users need to distinguish:
+
+- Initial runtime deployment
+- Upgrade progress
+- Upgrade completion
+- Upgrade failure
+- Last successfully deployed runtime image
+
+The operator also needs to trigger Deployment rollouts when projected ConfigMap
+configuration changes.
+
+Several implementation strategies are possible:
+
+- Read Pods directly
+- Read ReplicaSets directly
+- Poll runtime health endpoints
+- Observe the managed Deployment
+- Implement custom rollout machinery
+
+## Decision
+
+The operator will derive runtime upgrade state exclusively from the managed
+Deployment and the `TrussiumRuntime` desired image.
+
+No Pod or ReplicaSet reads are required.
+
+## Image Status
+
+The status contract contains:
+
+- `desiredImage`
+- `currentImage`
+- `lastSuccessfulImage`
+
+`desiredImage` represents the image requested by the current custom-resource
+specification.
+
+`currentImage` preserves its existing meaning as the image configured on the
+managed Deployment.
+
+`lastSuccessfulImage` records the image whose Deployment rollout most recently
+completed successfully.
+
+## Initial Deployment
+
+Initial runtime provisioning is not an upgrade.
+
+The first successful Deployment rollout establishes
+`lastSuccessfulImage`.
+
+## Upgrade Condition
+
+The operator maintains one condition:
+
+    Upgrading
+
+Stable reasons include:
+
+- `NoUpgrade`
+- `UpgradeInProgress`
+- `UpgradeComplete`
+- `UpgradeFailed`
+
+Existing runtime conditions continue to represent overall health and
+availability.
+
+## Upgrade Detection
+
+An image change is classified as an upgrade when:
+
+1. A previous successful image exists.
+2. The desired image differs from that image.
+
+Changes to configuration or other Pod-template settings do not constitute an
+image upgrade when the desired image remains unchanged.
+
+## Rollout Completion
+
+A non-zero replica rollout completes only when:
+
+- Deployment observed generation reaches the Deployment generation
+- Updated replicas equal desired replicas
+- Total replicas equal desired replicas
+- Ready replicas equal desired replicas
+- Available replicas equal desired replicas
+- Unavailable replicas equal zero
+
+A zero-replica rollout completes after the latest Deployment generation is
+observed and all replica counts are zero.
+
+## Rollout Failure
+
+The operator recognizes Deployment failure states including:
+
+- `ProgressDeadlineExceeded`
+- `ReplicaFailure`
+
+A failed upgrade does not modify the desired image.
+
+The previous `lastSuccessfulImage` remains unchanged.
+
+## Automatic Rollback
+
+The operator will not automatically roll back runtime image changes.
+
+The custom-resource specification remains authoritative.
+
+Rollback is an explicit desired-state change made by a user or higher-level
+automation.
+
+## Deployment Progress Deadline
+
+Managed Deployments use:
+
+    progressDeadlineSeconds: 600
+
+This provides a deterministic Kubernetes signal for stalled rollouts.
+
+## Configuration Rollouts
+
+The operator computes a deterministic SHA-256 checksum of the managed ConfigMap
+data and places it on the Deployment Pod template using:
+
+    runtime.trussium.io/config-checksum
+
+This causes configuration changes to create a new Deployment revision.
+
+Checksum generation:
+
+- Sorts keys deterministically
+- Includes operator-managed ConfigMap data
+- Excludes Secret values
+- Excludes timestamps
+- Excludes Kubernetes resource versions
+- Produces stable output for semantically identical configuration
+
+## Events
+
+The operator emits:
+
+- `RuntimeUpgradeStarted`
+- `RuntimeUpgradeCompleted`
+- `RuntimeUpgradeFailed`
+
+Events are transition-based and are not emitted repeatedly during unchanged
+reconciliation.
+
+## Compatibility
+
+Upgrade tracking treats image references as identities.
+
+It does not require semantic-version parsing.
+
+Compatibility is documented separately and is not yet enforced through
+admission or reconciliation.
+
+## Consequences
+
+### Positive
+
+- No additional Pod RBAC
+- No ReplicaSet RBAC
+- Kubernetes-native rollout observation
+- Explicit upgrade status
+- Stable successful-image history
+- Configuration-triggered rollouts
+- No polling loop
+- No hidden mutation of desired state
+
+### Negative
+
+- Deployment state is not equivalent to application-level semantic health.
+- Secret-value changes do not trigger rollouts automatically.
+- Failed upgrades require explicit operator or user action.
+- Compatibility is documented rather than enforced.
+
+## Alternatives Considered
+
+### Read Pods Directly
+
+Rejected because Deployment status already exposes the rollout information
+required by this milestone and direct Pod access would broaden RBAC.
+
+### Read ReplicaSets Directly
+
+Rejected because updated and total replica state is already available through
+Deployment status.
+
+### Automatic Rollback
+
+Rejected because silently mutating the desired image would violate the
+declarative custom-resource contract and could hide upgrade failures.
+
+### Periodic Polling
+
+Rejected because owned Deployment status changes already trigger
+reconciliation.
+
+## Follow-Up
+
+The next milestone will validate these contracts using envtest and real Kind
+clusters.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -18,3 +18,4 @@ boundaries for the Trussium Operator.
 - [0004 — Use Owner References for Managed Resources](0004-use-owner-references-for-managed-resources.md)
 - [0005 — Use Status Conditions and Transition Events](0005-use-status-conditions-and-transition-events.md)
 - [0006 — Enforce a Production Runtime Workload Contract](0006-enforce-production-runtime-workload-contract.md)
+- [0007 — Observe Runtime Upgrades Through Deployment Status](0007-observe-upgrades-through-deployment-status.md)

--- a/internal/controller/runtime_events.go
+++ b/internal/controller/runtime_events.go
@@ -25,17 +25,21 @@ import (
 )
 
 const (
-	eventReasonRuntimeProgressing   = "RuntimeProgressing"
-	eventReasonRuntimeReady         = "RuntimeReady"
-	eventReasonRuntimeRecovered     = "RuntimeRecovered"
-	eventReasonRuntimeScaledToZero  = "RuntimeScaledToZero"
-	eventReasonConfigurationInvalid = "ConfigurationInvalid"
-	eventReasonReconciliationFailed = "ReconciliationFailed"
-	eventReasonRuntimeDegraded      = "RuntimeDegraded"
+	eventReasonRuntimeProgressing      = "RuntimeProgressing"
+	eventReasonRuntimeReady            = "RuntimeReady"
+	eventReasonRuntimeRecovered        = "RuntimeRecovered"
+	eventReasonRuntimeScaledToZero     = "RuntimeScaledToZero"
+	eventReasonConfigurationInvalid    = "ConfigurationInvalid"
+	eventReasonReconciliationFailed    = "ReconciliationFailed"
+	eventReasonRuntimeDegraded         = "RuntimeDegraded"
+	eventReasonRuntimeUpgradeStarted   = "RuntimeUpgradeStarted"
+	eventReasonRuntimeUpgradeCompleted = "RuntimeUpgradeCompleted"
+	eventReasonRuntimeUpgradeFailed    = "RuntimeUpgradeFailed"
 
 	eventActionReconcileRuntime      = "ReconcileRuntime"
 	eventActionValidateConfiguration = "ValidateConfiguration"
 	eventActionObserveRuntime        = "ObserveRuntime"
+	eventActionUpgradeRuntime        = "UpgradeRuntime"
 )
 
 // recordStatusTransitionEvents emits Events only when a meaningful condition
@@ -50,6 +54,11 @@ func (r *TrussiumRuntimeReconciler) recordStatusTransitionEvents(
 	}
 
 	r.recordConfigurationTransition(
+		runtimeResource,
+		previousStatus,
+		currentStatus,
+	)
+	r.recordUpgradeTransition(
 		runtimeResource,
 		previousStatus,
 		currentStatus,
@@ -244,6 +253,111 @@ func (r *TrussiumRuntimeReconciler) recordReconciliationFailure(
 		"Runtime reconciliation failed: %v",
 		reconciliationError,
 	)
+}
+
+func (r *TrussiumRuntimeReconciler) recordUpgradeTransition(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	previousStatus runtimev1alpha1.TrussiumRuntimeStatus,
+	currentStatus runtimev1alpha1.TrussiumRuntimeStatus,
+) {
+	if !conditionChanged(
+		previousStatus,
+		currentStatus,
+		conditionTypeUpgrading,
+	) {
+		return
+	}
+
+	condition := runtimeCondition(
+		currentStatus,
+		conditionTypeUpgrading,
+	)
+	if condition == nil {
+		return
+	}
+
+	sourceImage := previousStatus.LastSuccessfulImage
+	destinationImage := currentStatus.DesiredImage
+
+	switch condition.Reason {
+	case reasonUpgradeInProgress:
+		if condition.Status != metav1.ConditionTrue {
+			return
+		}
+
+		if !validUpgradeEventImages(
+			sourceImage,
+			destinationImage,
+		) {
+			return
+		}
+
+		r.Recorder.Eventf(
+			runtimeResource,
+			nil,
+			corev1.EventTypeNormal,
+			eventReasonRuntimeUpgradeStarted,
+			eventActionUpgradeRuntime,
+			"Runtime image upgrade started from %s to %s.",
+			sourceImage,
+			destinationImage,
+		)
+
+	case reasonUpgradeComplete:
+		if condition.Status != metav1.ConditionFalse {
+			return
+		}
+
+		if !validUpgradeEventImages(
+			sourceImage,
+			destinationImage,
+		) {
+			return
+		}
+
+		r.Recorder.Eventf(
+			runtimeResource,
+			nil,
+			corev1.EventTypeNormal,
+			eventReasonRuntimeUpgradeCompleted,
+			eventActionUpgradeRuntime,
+			"Runtime image upgrade completed from %s to %s.",
+			sourceImage,
+			destinationImage,
+		)
+
+	case reasonUpgradeFailed:
+		if condition.Status != metav1.ConditionFalse {
+			return
+		}
+
+		if !validUpgradeEventImages(
+			sourceImage,
+			destinationImage,
+		) {
+			return
+		}
+
+		r.Recorder.Eventf(
+			runtimeResource,
+			nil,
+			corev1.EventTypeWarning,
+			eventReasonRuntimeUpgradeFailed,
+			eventActionUpgradeRuntime,
+			"Runtime image upgrade failed from %s to %s.",
+			sourceImage,
+			destinationImage,
+		)
+	}
+}
+
+func validUpgradeEventImages(
+	sourceImage string,
+	destinationImage string,
+) bool {
+	return sourceImage != "" &&
+		destinationImage != "" &&
+		sourceImage != destinationImage
 }
 
 // Compile-time verification that the Kubernetes recorder satisfies the

--- a/internal/controller/runtime_resources.go
+++ b/internal/controller/runtime_resources.go
@@ -17,8 +17,12 @@ limitations under the License.
 package controller
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"maps"
+	"slices"
 	"strconv"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -35,15 +39,17 @@ const (
 	runtimeHTTPPortName  = "http"
 	runtimeHTTPPort      = int32(9000)
 
-	runtimeUserID                  = int64(10001)
-	runtimeGroupID                 = int64(10001)
-	defaultShutdownDrainSeconds    = int32(30)
-	terminationGraceMarginSeconds  = int64(6)
-	defaultTerminationGraceSeconds = int64(36)
-	deploymentRevisionHistoryLimit = int32(3)
-	topologyHostnameKey            = "kubernetes.io/hostname"
-	healthLivePath                 = "/health/live"
-	healthReadyPath                = "/health/ready"
+	runtimeUserID                     = int64(10001)
+	runtimeGroupID                    = int64(10001)
+	defaultShutdownDrainSeconds       = int32(30)
+	terminationGraceMarginSeconds     = int64(6)
+	defaultTerminationGraceSeconds    = int64(36)
+	deploymentRevisionHistoryLimit    = int32(3)
+	runtimeConfigChecksumAnnotation   = "runtime.trussium.io/config-checksum"
+	deploymentProgressDeadlineSeconds = int32(600)
+	topologyHostnameKey               = "kubernetes.io/hostname"
+	healthLivePath                    = "/health/live"
+	healthReadyPath                   = "/health/ready"
 
 	envEnvironment             = "TRUSSIUM_ENVIRONMENT"
 	envRuntimeHost             = "TRUSSIUM_RUNTIME__HOST"
@@ -172,20 +178,19 @@ func mergedPodLabels(
 func podAnnotations(
 	runtimeResource *runtimev1alpha1.TrussiumRuntime,
 ) map[string]string {
-	if runtimeResource.Spec.PodMetadata == nil ||
-		len(runtimeResource.Spec.PodMetadata.Annotations) == 0 {
-		return nil
+	annotations := make(map[string]string)
+
+	if runtimeResource.Spec.PodMetadata != nil {
+		maps.Copy(
+			annotations,
+			runtimeResource.Spec.PodMetadata.Annotations,
+		)
 	}
 
-	annotations := make(
-		map[string]string,
-		len(runtimeResource.Spec.PodMetadata.Annotations),
-	)
-
-	maps.Copy(
-		annotations,
-		runtimeResource.Spec.PodMetadata.Annotations,
-	)
+	annotations[runtimeConfigChecksumAnnotation] =
+		runtimeConfigChecksum(
+			runtimeConfigData(runtimeResource),
+		)
 
 	return annotations
 }
@@ -278,6 +283,39 @@ func runtimeConfigData(
 	}
 
 	return data
+}
+
+func runtimeConfigChecksum(
+	data map[string]string,
+) string {
+	keys := make([]string, 0, len(data))
+
+	for key := range data {
+		keys = append(keys, key)
+	}
+
+	slices.Sort(keys)
+
+	var payload strings.Builder
+
+	for _, key := range keys {
+		value := data[key]
+
+		payload.WriteString(strconv.Itoa(len(key)))
+		payload.WriteByte(':')
+		payload.WriteString(key)
+		payload.WriteByte(':')
+		payload.WriteString(strconv.Itoa(len(value)))
+		payload.WriteByte(':')
+		payload.WriteString(value)
+		payload.WriteByte(';')
+	}
+
+	checksum := sha256.Sum256(
+		[]byte(payload.String()),
+	)
+
+	return hex.EncodeToString(checksum[:])
 }
 
 // buildConfigMap constructs the desired runtime ConfigMap.
@@ -378,6 +416,9 @@ func buildDeployment(
 		},
 		Spec: appsv1.DeploymentSpec{
 			Replicas: ptr.To(desiredReplicas(runtimeResource)),
+			ProgressDeadlineSeconds: ptr.To(
+				deploymentProgressDeadlineSeconds,
+			),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels,
 			},

--- a/internal/controller/runtime_resources_test.go
+++ b/internal/controller/runtime_resources_test.go
@@ -79,10 +79,10 @@ func TestRuntimeConfigData(t *testing.T) {
 	actual := runtimeConfigData(runtimeResource)
 
 	expected := map[string]string{
-		envEnvironment:            "production",
+		envEnvironment:            defaultRuntimeEnvironment,
 		envRuntimeHost:            "0.0.0.0",
 		envRuntimePort:            "9000",
-		envProviderName:           "ollama",
+		envProviderName:           testProviderName,
 		envProviderBaseURL:        baseURL,
 		envProviderRequestSeconds: "75",
 		envProviderStreamIdle:     "40",
@@ -337,7 +337,7 @@ func newTestRuntime() *runtimev1alpha1.TrussiumRuntime {
 			Kind:       "TrussiumRuntime",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "production",
+			Name:      defaultRuntimeEnvironment,
 			Namespace: testRuntimeNamespace,
 		},
 		Spec: runtimev1alpha1.TrussiumRuntimeSpec{

--- a/internal/controller/runtime_status.go
+++ b/internal/controller/runtime_status.go
@@ -38,6 +38,7 @@ const (
 	conditionTypeAvailable          = "Available"
 	conditionTypeReady              = "Ready"
 	conditionTypeDegraded           = "Degraded"
+	conditionTypeUpgrading          = "Upgrading"
 
 	reasonReferencesResolved          = "ReferencesResolved"
 	reasonSecretNotFound              = "SecretNotFound"
@@ -56,6 +57,10 @@ const (
 	reasonProgressDeadlineExceeded    = "ProgressDeadlineExceeded"
 	reasonReplicaFailure              = "ReplicaFailure"
 	reasonReconciliationFailed        = "ReconciliationFailed"
+	reasonNoUpgrade                   = "NoUpgrade"
+	reasonUpgradeInProgress           = "UpgradeInProgress"
+	reasonUpgradeComplete             = "UpgradeComplete"
+	reasonUpgradeFailed               = "UpgradeFailed"
 )
 
 type referenceValidationResult struct {
@@ -203,7 +208,110 @@ func (r *TrussiumRuntimeReconciler) loadRuntimeObservation(
 	return observation, nil
 }
 
+type deploymentRolloutState int
+
+const (
+	deploymentRolloutProgressing deploymentRolloutState = iota
+	deploymentRolloutComplete
+	deploymentRolloutFailed
+)
+
+func observeDeploymentRollout(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	deployment *appsv1.Deployment,
+) deploymentRolloutState {
+	if deployment == nil {
+		return deploymentRolloutProgressing
+	}
+
+	if deploymentHasRolloutFailure(deployment) {
+		return deploymentRolloutFailed
+	}
+
+	if deployment.Status.ObservedGeneration <
+		deployment.Generation {
+		return deploymentRolloutProgressing
+	}
+
+	desired := desiredReplicas(runtimeResource)
+
+	if desired == 0 {
+		if deployment.Status.Replicas != 0 ||
+			deployment.Status.UpdatedReplicas != 0 ||
+			deployment.Status.ReadyReplicas != 0 ||
+			deployment.Status.AvailableReplicas != 0 ||
+			deployment.Status.UnavailableReplicas != 0 {
+			return deploymentRolloutProgressing
+		}
+
+		return deploymentRolloutComplete
+	}
+
+	if deployment.Status.UpdatedReplicas != desired {
+		return deploymentRolloutProgressing
+	}
+
+	if deployment.Status.Replicas != desired {
+		return deploymentRolloutProgressing
+	}
+
+	if deployment.Status.ReadyReplicas != desired {
+		return deploymentRolloutProgressing
+	}
+
+	if deployment.Status.AvailableReplicas != desired {
+		return deploymentRolloutProgressing
+	}
+
+	if deployment.Status.UnavailableReplicas != 0 {
+		return deploymentRolloutProgressing
+	}
+
+	return deploymentRolloutComplete
+}
+
+func deploymentHasRolloutFailure(
+	deployment *appsv1.Deployment,
+) bool {
+	if deployment == nil {
+		return false
+	}
+
+	for _, condition := range deployment.Status.Conditions {
+		if condition.Type == appsv1.DeploymentProgressing &&
+			condition.Status == corev1.ConditionFalse &&
+			condition.Reason == reasonProgressDeadlineExceeded {
+			return true
+		}
+
+		if condition.Type == appsv1.DeploymentReplicaFailure &&
+			condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
 func buildRuntimeStatus(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	observation runtimeObservation,
+	validation referenceValidationResult,
+) runtimev1alpha1.TrussiumRuntimeStatus {
+	status := buildBaseRuntimeStatus(
+		runtimeResource,
+		observation,
+		validation,
+	)
+
+	return applyUpgradeStatus(
+		runtimeResource,
+		observation.Deployment,
+		status,
+	)
+}
+
+func buildBaseRuntimeStatus(
 	runtimeResource *runtimev1alpha1.TrussiumRuntime,
 	observation runtimeObservation,
 	validation referenceValidationResult,
@@ -213,6 +321,7 @@ func buildRuntimeStatus(
 	status.ObservedGeneration = runtimeResource.Generation
 	status.ReadyReplicas = 0
 	status.AvailableReplicas = 0
+	status.DesiredImage = runtimeImage(runtimeResource.Spec.Image)
 	status.CurrentImage = deploymentCurrentImage(
 		observation.Deployment,
 	)
@@ -739,10 +848,7 @@ func copyRuntimeStatus(
 	status runtimev1alpha1.TrussiumRuntimeStatus,
 ) runtimev1alpha1.TrussiumRuntimeStatus {
 	copiedStatus := status
-	copiedStatus.Conditions = append(
-		[]metav1.Condition(nil),
-		status.Conditions...,
-	)
+	copiedStatus.Conditions = slices.Clone(status.Conditions)
 
 	return copiedStatus
 }
@@ -812,4 +918,134 @@ func (r *TrussiumRuntimeReconciler) updateRuntimeStatus(
 	}
 
 	return true, nil
+}
+
+func applyUpgradeStatus(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	deployment *appsv1.Deployment,
+	status runtimev1alpha1.TrussiumRuntimeStatus,
+) runtimev1alpha1.TrussiumRuntimeStatus {
+	desiredImage := runtimeImage(
+		runtimeResource.Spec.Image,
+	)
+
+	status.DesiredImage = desiredImage
+
+	rolloutState := observeDeploymentRollout(
+		runtimeResource,
+		deployment,
+	)
+
+	lastSuccessfulImage :=
+		status.LastSuccessfulImage
+
+	// The first successful Deployment establishes the initial successful
+	// runtime image. Initial deployment is not classified as an upgrade.
+	if lastSuccessfulImage == "" {
+		if rolloutState == deploymentRolloutComplete &&
+			deploymentCurrentImage(deployment) == desiredImage {
+			status.LastSuccessfulImage =
+				desiredImage
+		}
+
+		setRuntimeCondition(
+			&status,
+			runtimeResource.Generation,
+			conditionTypeUpgrading,
+			metav1.ConditionFalse,
+			reasonNoUpgrade,
+			"No runtime image upgrade is in progress.",
+		)
+
+		return status
+	}
+
+	// Reconciliation may roll configuration, metadata, scheduling, or other
+	// Pod-template changes without changing the runtime image. Those are not
+	// runtime image upgrades.
+	if desiredImage == lastSuccessfulImage {
+		existingCondition := runtimeCondition(
+			status,
+			conditionTypeUpgrading,
+		)
+
+		if existingCondition == nil {
+			setRuntimeCondition(
+				&status,
+				runtimeResource.Generation,
+				conditionTypeUpgrading,
+				metav1.ConditionFalse,
+				reasonNoUpgrade,
+				"No runtime image upgrade is in progress.",
+			)
+		}
+
+		return status
+	}
+
+	switch rolloutState {
+	case deploymentRolloutFailed:
+		setRuntimeCondition(
+			&status,
+			runtimeResource.Generation,
+			conditionTypeUpgrading,
+			metav1.ConditionFalse,
+			reasonUpgradeFailed,
+			fmt.Sprintf(
+				"Runtime image upgrade from %s to %s failed.",
+				lastSuccessfulImage,
+				desiredImage,
+			),
+		)
+
+	case deploymentRolloutComplete:
+		if deploymentCurrentImage(deployment) != desiredImage {
+			setRuntimeCondition(
+				&status,
+				runtimeResource.Generation,
+				conditionTypeUpgrading,
+				metav1.ConditionTrue,
+				reasonUpgradeInProgress,
+				fmt.Sprintf(
+					"Runtime image is transitioning from %s to %s.",
+					lastSuccessfulImage,
+					desiredImage,
+				),
+			)
+
+			return status
+		}
+
+		status.LastSuccessfulImage =
+			desiredImage
+
+		setRuntimeCondition(
+			&status,
+			runtimeResource.Generation,
+			conditionTypeUpgrading,
+			metav1.ConditionFalse,
+			reasonUpgradeComplete,
+			fmt.Sprintf(
+				"Runtime image upgrade from %s to %s completed.",
+				lastSuccessfulImage,
+				desiredImage,
+			),
+		)
+
+	default:
+		setRuntimeCondition(
+			&status,
+			runtimeResource.Generation,
+			conditionTypeUpgrading,
+			metav1.ConditionTrue,
+			reasonUpgradeInProgress,
+			fmt.Sprintf(
+				"Runtime image is upgrading from %s to %s.",
+				lastSuccessfulImage,
+				desiredImage,
+			),
+		)
+	}
+
+	return status
 }

--- a/internal/controller/runtime_upgrade_events_test.go
+++ b/internal/controller/runtime_upgrade_events_test.go
@@ -1,0 +1,410 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/events"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+func TestRuntimeUpgradeStartedEvent(t *testing.T) {
+	t.Parallel()
+
+	recorder := events.NewFakeRecorder(10)
+
+	reconciler := TrussiumRuntimeReconciler{
+		Recorder: recorder,
+	}
+
+	runtimeResource := newTestRuntime()
+
+	previousStatus := runtimev1alpha1.TrussiumRuntimeStatus{
+		DesiredImage:        testRuntimeImage,
+		CurrentImage:        testRuntimeImage,
+		LastSuccessfulImage: testRuntimeImage,
+	}
+
+	setRuntimeCondition(
+		&previousStatus,
+		1,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonNoUpgrade,
+		"No runtime image upgrade is in progress.",
+	)
+
+	currentStatus := copyRuntimeStatus(previousStatus)
+	currentStatus.DesiredImage =
+		testUpgradeRuntimeImage
+	currentStatus.CurrentImage =
+		testUpgradeRuntimeImage
+
+	setRuntimeCondition(
+		&currentStatus,
+		2,
+		conditionTypeUpgrading,
+		metav1.ConditionTrue,
+		reasonUpgradeInProgress,
+		"Runtime image upgrade is in progress.",
+	)
+
+	reconciler.recordStatusTransitionEvents(
+		runtimeResource,
+		previousStatus,
+		currentStatus,
+	)
+
+	recordedEvents := drainRecordedEvents(recorder)
+
+	assertUpgradeEvent(
+		t,
+		recordedEvents,
+		eventReasonRuntimeUpgradeStarted,
+		testRuntimeImage,
+		testUpgradeRuntimeImage,
+	)
+}
+
+func TestRuntimeUpgradeCompletedEvent(t *testing.T) {
+	t.Parallel()
+
+	recorder := events.NewFakeRecorder(10)
+
+	reconciler := TrussiumRuntimeReconciler{
+		Recorder: recorder,
+	}
+
+	runtimeResource := newTestRuntime()
+
+	previousStatus := runtimev1alpha1.TrussiumRuntimeStatus{
+		DesiredImage:        testUpgradeRuntimeImage,
+		CurrentImage:        testUpgradeRuntimeImage,
+		LastSuccessfulImage: testRuntimeImage,
+	}
+
+	setRuntimeCondition(
+		&previousStatus,
+		2,
+		conditionTypeUpgrading,
+		metav1.ConditionTrue,
+		reasonUpgradeInProgress,
+		"Runtime image upgrade is in progress.",
+	)
+
+	currentStatus := copyRuntimeStatus(previousStatus)
+	currentStatus.LastSuccessfulImage =
+		testUpgradeRuntimeImage
+
+	setRuntimeCondition(
+		&currentStatus,
+		2,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeComplete,
+		"Runtime image upgrade completed.",
+	)
+
+	reconciler.recordStatusTransitionEvents(
+		runtimeResource,
+		previousStatus,
+		currentStatus,
+	)
+
+	recordedEvents := drainRecordedEvents(recorder)
+
+	assertUpgradeEvent(
+		t,
+		recordedEvents,
+		eventReasonRuntimeUpgradeCompleted,
+		testRuntimeImage,
+		testUpgradeRuntimeImage,
+	)
+}
+
+func TestRuntimeUpgradeFailedEvent(t *testing.T) {
+	t.Parallel()
+
+	recorder := events.NewFakeRecorder(10)
+
+	reconciler := TrussiumRuntimeReconciler{
+		Recorder: recorder,
+	}
+
+	runtimeResource := newTestRuntime()
+
+	previousStatus := runtimev1alpha1.TrussiumRuntimeStatus{
+		DesiredImage:        testUpgradeRuntimeImage,
+		CurrentImage:        testUpgradeRuntimeImage,
+		LastSuccessfulImage: testRuntimeImage,
+	}
+
+	setRuntimeCondition(
+		&previousStatus,
+		2,
+		conditionTypeUpgrading,
+		metav1.ConditionTrue,
+		reasonUpgradeInProgress,
+		"Runtime image upgrade is in progress.",
+	)
+
+	currentStatus := copyRuntimeStatus(previousStatus)
+
+	setRuntimeCondition(
+		&currentStatus,
+		2,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeFailed,
+		"Runtime image upgrade failed.",
+	)
+
+	reconciler.recordStatusTransitionEvents(
+		runtimeResource,
+		previousStatus,
+		currentStatus,
+	)
+
+	recordedEvents := drainRecordedEvents(recorder)
+
+	assertUpgradeEvent(
+		t,
+		recordedEvents,
+		eventReasonRuntimeUpgradeFailed,
+		testRuntimeImage,
+		testUpgradeRuntimeImage,
+	)
+}
+
+func TestInitialDeploymentDoesNotEmitUpgradeEvent(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	recorder := events.NewFakeRecorder(10)
+
+	reconciler := TrussiumRuntimeReconciler{
+		Recorder: recorder,
+	}
+
+	runtimeResource := newTestRuntime()
+
+	previousStatus :=
+		runtimev1alpha1.TrussiumRuntimeStatus{}
+
+	currentStatus :=
+		runtimev1alpha1.TrussiumRuntimeStatus{
+			DesiredImage:        testRuntimeImage,
+			CurrentImage:        testRuntimeImage,
+			LastSuccessfulImage: testRuntimeImage,
+		}
+
+	setRuntimeCondition(
+		&currentStatus,
+		1,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonNoUpgrade,
+		"No runtime image upgrade is in progress.",
+	)
+
+	reconciler.recordStatusTransitionEvents(
+		runtimeResource,
+		previousStatus,
+		currentStatus,
+	)
+
+	recordedEvents := drainRecordedEvents(recorder)
+
+	for _, recordedEvent := range recordedEvents {
+		if strings.Contains(
+			recordedEvent,
+			eventReasonRuntimeUpgradeStarted,
+		) ||
+			strings.Contains(
+				recordedEvent,
+				eventReasonRuntimeUpgradeCompleted,
+			) ||
+			strings.Contains(
+				recordedEvent,
+				eventReasonRuntimeUpgradeFailed,
+			) {
+			t.Fatalf(
+				"initial deployment must not emit an upgrade Event: %q",
+				recordedEvent,
+			)
+		}
+	}
+}
+
+func TestUnchangedUpgradeStateDoesNotEmitDuplicateEvent(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	recorder := events.NewFakeRecorder(10)
+
+	reconciler := TrussiumRuntimeReconciler{
+		Recorder: recorder,
+	}
+
+	runtimeResource := newTestRuntime()
+
+	previousStatus := runtimev1alpha1.TrussiumRuntimeStatus{
+		DesiredImage:        testUpgradeRuntimeImage,
+		CurrentImage:        testUpgradeRuntimeImage,
+		LastSuccessfulImage: testRuntimeImage,
+	}
+
+	setRuntimeCondition(
+		&previousStatus,
+		2,
+		conditionTypeUpgrading,
+		metav1.ConditionTrue,
+		reasonUpgradeInProgress,
+		"Runtime image upgrade is in progress.",
+	)
+
+	currentStatus := copyRuntimeStatus(previousStatus)
+
+	reconciler.recordStatusTransitionEvents(
+		runtimeResource,
+		previousStatus,
+		currentStatus,
+	)
+
+	recordedEvents := drainRecordedEvents(recorder)
+
+	if len(recordedEvents) != 0 {
+		t.Fatalf(
+			"expected no duplicate Event, received %#v",
+			recordedEvents,
+		)
+	}
+}
+
+func TestValidUpgradeEventImages(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		source      string
+		destination string
+		expected    bool
+	}{
+		{
+			name:        "valid transition",
+			source:      testRuntimeImage,
+			destination: testUpgradeRuntimeImage,
+			expected:    true,
+		},
+		{
+			name:        "missing source",
+			source:      "",
+			destination: testUpgradeRuntimeImage,
+			expected:    false,
+		},
+		{
+			name:        "missing destination",
+			source:      testRuntimeImage,
+			destination: "",
+			expected:    false,
+		},
+		{
+			name:        "same image",
+			source:      testRuntimeImage,
+			destination: testRuntimeImage,
+			expected:    false,
+		},
+	}
+
+	for _, testCase := range testCases {
+
+		t.Run(
+			testCase.name,
+			func(t *testing.T) {
+				t.Parallel()
+
+				actual := validUpgradeEventImages(
+					testCase.source,
+					testCase.destination,
+				)
+
+				if actual != testCase.expected {
+					t.Fatalf(
+						"expected %t, received %t",
+						testCase.expected,
+						actual,
+					)
+				}
+			},
+		)
+	}
+}
+
+func assertUpgradeEvent(
+	t *testing.T,
+	recordedEvents []string,
+	reason string,
+	sourceImage string,
+	destinationImage string,
+) {
+	t.Helper()
+
+	for _, recordedEvent := range recordedEvents {
+		if !strings.Contains(
+			recordedEvent,
+			reason,
+		) {
+			continue
+		}
+
+		if !strings.Contains(
+			recordedEvent,
+			sourceImage,
+		) {
+			t.Fatalf(
+				"Event %q does not contain source image %q",
+				recordedEvent,
+				sourceImage,
+			)
+		}
+
+		if !strings.Contains(
+			recordedEvent,
+			destinationImage,
+		) {
+			t.Fatalf(
+				"Event %q does not contain destination image %q",
+				recordedEvent,
+				destinationImage,
+			)
+		}
+
+		return
+	}
+
+	t.Fatalf(
+		"expected Event reason %q, received %#v",
+		reason,
+		recordedEvents,
+	)
+}

--- a/internal/controller/runtime_upgrade_test.go
+++ b/internal/controller/runtime_upgrade_test.go
@@ -1,0 +1,556 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+func TestRuntimeConfigChecksumIsStable(t *testing.T) {
+	t.Parallel()
+
+	first := map[string]string{
+		envProviderName:          testProviderName,
+		"TRUSSIUM_RUNTIME__PORT": "9000",
+		"TRUSSIUM_ENVIRONMENT":   defaultRuntimeEnvironment,
+	}
+
+	second := map[string]string{
+		"TRUSSIUM_ENVIRONMENT":   defaultRuntimeEnvironment,
+		"TRUSSIUM_RUNTIME__PORT": "9000",
+		envProviderName:          testProviderName,
+	}
+
+	firstChecksum := runtimeConfigChecksum(first)
+	secondChecksum := runtimeConfigChecksum(second)
+
+	if firstChecksum != secondChecksum {
+		t.Fatalf(
+			"expected stable checksum, received %q and %q",
+			firstChecksum,
+			secondChecksum,
+		)
+	}
+}
+
+func TestRuntimeConfigChecksumChangesWithConfiguration(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	first := map[string]string{
+		envProviderName: testProviderName,
+	}
+
+	second := map[string]string{
+		envProviderName: "openai",
+	}
+
+	if runtimeConfigChecksum(first) ==
+		runtimeConfigChecksum(second) {
+		t.Fatal(
+			"expected configuration change to alter checksum",
+		)
+	}
+}
+
+func TestBuildDeploymentProjectsConfigurationChecksum(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	deployment := buildDeployment(runtimeResource)
+
+	actual :=
+		deployment.Spec.Template.Annotations[runtimeConfigChecksumAnnotation]
+
+	expected := runtimeConfigChecksum(
+		runtimeConfigData(runtimeResource),
+	)
+
+	if actual != expected {
+		t.Fatalf(
+			"expected configuration checksum %q, received %q",
+			expected,
+			actual,
+		)
+	}
+
+	if actual == "" {
+		t.Fatal(
+			"expected configuration checksum annotation",
+		)
+	}
+}
+
+func TestConfigurationChangeChangesPodTemplateChecksum(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	firstRuntime := newTestRuntime()
+	secondRuntime := newTestRuntime()
+
+	secondRuntime.Spec.Provider.Type =
+		runtimev1alpha1.ProviderTypeOpenAI
+
+	firstDeployment := buildDeployment(firstRuntime)
+	secondDeployment := buildDeployment(secondRuntime)
+
+	firstChecksum :=
+		firstDeployment.Spec.Template.Annotations[runtimeConfigChecksumAnnotation]
+
+	secondChecksum :=
+		secondDeployment.Spec.Template.Annotations[runtimeConfigChecksumAnnotation]
+
+	if firstChecksum == secondChecksum {
+		t.Fatalf(
+			"expected runtime configuration change to alter Pod template checksum, both were %q",
+			firstChecksum,
+		)
+	}
+}
+
+func TestUserCannotOverrideConfigurationChecksum(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	runtimeResource.Spec.PodMetadata =
+		&runtimev1alpha1.PodMetadataSpec{
+			Annotations: map[string]string{
+				runtimeConfigChecksumAnnotation: "user-controlled-value",
+			},
+		}
+
+	deployment := buildDeployment(runtimeResource)
+
+	actual := deployment.Spec.Template.Annotations[runtimeConfigChecksumAnnotation]
+
+	expected := runtimeConfigChecksum(
+		runtimeConfigData(runtimeResource),
+	)
+
+	if actual != expected {
+		t.Fatalf(
+			"expected operator checksum %q, received %q",
+			expected,
+			actual,
+		)
+	}
+
+	if actual == "user-controlled-value" {
+		t.Fatal(
+			"configuration checksum annotation must remain operator-owned",
+		)
+	}
+}
+
+func TestBuildDeploymentSetsProgressDeadline(t *testing.T) {
+	t.Parallel()
+
+	deployment := buildDeployment(newTestRuntime())
+
+	if deployment.Spec.ProgressDeadlineSeconds == nil {
+		t.Fatal(
+			"expected Deployment progress deadline",
+		)
+	}
+
+	if *deployment.Spec.ProgressDeadlineSeconds !=
+		deploymentProgressDeadlineSeconds {
+		t.Fatalf(
+			"expected progress deadline %d, received %d",
+			deploymentProgressDeadlineSeconds,
+			*deployment.Spec.ProgressDeadlineSeconds,
+		)
+	}
+}
+
+func TestBuildRuntimeStatusReportsDesiredImage(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{},
+		validReferenceValidation(),
+	)
+
+	if status.DesiredImage != testRuntimeImage {
+		t.Fatalf(
+			"expected desired image %q, received %q",
+			testRuntimeImage,
+			status.DesiredImage,
+		)
+	}
+
+	if status.LastSuccessfulImage != "" {
+		t.Fatalf(
+			"expected no successful image before rollout completion, received %q",
+			status.LastSuccessfulImage,
+		)
+	}
+}
+
+func completedDeployment(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) *appsv1.Deployment {
+	deployment := buildDeployment(runtimeResource)
+	deployment.Generation = 3
+
+	desired := desiredReplicas(runtimeResource)
+
+	deployment.Status.ObservedGeneration = 3
+	deployment.Status.Replicas = desired
+	deployment.Status.UpdatedReplicas = desired
+	deployment.Status.ReadyReplicas = desired
+	deployment.Status.AvailableReplicas = desired
+	deployment.Status.UnavailableReplicas = 0
+
+	deployment.Status.Conditions =
+		[]appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentProgressing,
+				Status: corev1.ConditionTrue,
+				Reason: "NewReplicaSetAvailable",
+			},
+		}
+
+	return deployment
+}
+
+func setUpgradeImage(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+) {
+	runtimeResource.Spec.Image.Tag =
+		ptr.To(testUpgradeRuntimeTag)
+
+	runtimeResource.Spec.Image.Digest = nil
+}
+
+func TestInitialRolloutEstablishesSuccessfulImage(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	deployment := completedDeployment(runtimeResource)
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	if status.LastSuccessfulImage != testRuntimeImage {
+		t.Fatalf(
+			"expected initial successful image %q, received %q",
+			testRuntimeImage,
+			status.LastSuccessfulImage,
+		)
+	}
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonNoUpgrade,
+	)
+}
+
+func TestRuntimeImageUpgradeProgressing(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	runtimeResource.Status.LastSuccessfulImage =
+		testRuntimeImage
+
+	setUpgradeImage(runtimeResource)
+
+	deployment := buildDeployment(runtimeResource)
+	deployment.Generation = 4
+	deployment.Status.ObservedGeneration = 3
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	if status.DesiredImage != testUpgradeRuntimeImage {
+		t.Fatalf(
+			"expected desired image %q, received %q",
+			testUpgradeRuntimeImage,
+			status.DesiredImage,
+		)
+	}
+
+	if status.LastSuccessfulImage != testRuntimeImage {
+		t.Fatalf(
+			"expected successful image to remain %q, received %q",
+			testRuntimeImage,
+			status.LastSuccessfulImage,
+		)
+	}
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionTrue,
+		reasonUpgradeInProgress,
+	)
+}
+
+func TestRuntimeImageUpgradeCompletes(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	runtimeResource.Status.LastSuccessfulImage =
+		testRuntimeImage
+
+	setUpgradeImage(runtimeResource)
+
+	deployment := completedDeployment(runtimeResource)
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	if status.LastSuccessfulImage !=
+		testUpgradeRuntimeImage {
+		t.Fatalf(
+			"expected successful image %q, received %q",
+			testUpgradeRuntimeImage,
+			status.LastSuccessfulImage,
+		)
+	}
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeComplete,
+	)
+}
+
+func TestRuntimeImageUpgradeFailurePreservesSuccessfulImage(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	runtimeResource.Status.LastSuccessfulImage =
+		testRuntimeImage
+
+	setUpgradeImage(runtimeResource)
+
+	deployment := buildDeployment(runtimeResource)
+	deployment.Generation = 4
+	deployment.Status.ObservedGeneration = 4
+
+	deployment.Status.Conditions =
+		[]appsv1.DeploymentCondition{
+			{
+				Type:    appsv1.DeploymentProgressing,
+				Status:  corev1.ConditionFalse,
+				Reason:  reasonProgressDeadlineExceeded,
+				Message: "Deployment exceeded its progress deadline.",
+			},
+		}
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	if status.LastSuccessfulImage != testRuntimeImage {
+		t.Fatalf(
+			"expected failed upgrade to preserve %q, received %q",
+			testRuntimeImage,
+			status.LastSuccessfulImage,
+		)
+	}
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeFailed,
+	)
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeDegraded,
+		metav1.ConditionTrue,
+		reasonProgressDeadlineExceeded,
+	)
+}
+
+func TestConfigurationRolloutIsNotRuntimeImageUpgrade(
+	t *testing.T,
+) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	runtimeResource.Status.LastSuccessfulImage =
+		testRuntimeImage
+
+	deployment := buildDeployment(runtimeResource)
+	deployment.Generation = 5
+	deployment.Status.ObservedGeneration = 4
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	if status.LastSuccessfulImage != testRuntimeImage {
+		t.Fatalf(
+			"expected successful image %q, received %q",
+			testRuntimeImage,
+			status.LastSuccessfulImage,
+		)
+	}
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonNoUpgrade,
+	)
+}
+
+func TestScaleToZeroImageUpgradeCompletes(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+
+	runtimeResource.Status.LastSuccessfulImage =
+		testRuntimeImage
+
+	runtimeResource.Spec.Replicas = ptr.To(int32(0))
+
+	setUpgradeImage(runtimeResource)
+
+	deployment := buildDeployment(runtimeResource)
+	deployment.Generation = 6
+	deployment.Status.ObservedGeneration = 6
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	if status.LastSuccessfulImage !=
+		testUpgradeRuntimeImage {
+		t.Fatalf(
+			"expected scaled-to-zero successful image %q, received %q",
+			testUpgradeRuntimeImage,
+			status.LastSuccessfulImage,
+		)
+	}
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeComplete,
+	)
+}
+
+func TestCompletedUpgradeStateIsPreserved(t *testing.T) {
+	t.Parallel()
+
+	runtimeResource := newTestRuntime()
+	setUpgradeImage(runtimeResource)
+
+	runtimeResource.Status.DesiredImage =
+		testUpgradeRuntimeImage
+	runtimeResource.Status.CurrentImage =
+		testUpgradeRuntimeImage
+	runtimeResource.Status.LastSuccessfulImage =
+		testUpgradeRuntimeImage
+
+	setRuntimeCondition(
+		&runtimeResource.Status,
+		4,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeComplete,
+		"Runtime image upgrade completed.",
+	)
+
+	deployment := completedDeployment(
+		runtimeResource,
+	)
+
+	status := buildRuntimeStatus(
+		runtimeResource,
+		runtimeObservation{
+			Deployment: deployment,
+		},
+		validReferenceValidation(),
+	)
+
+	assertRuntimeCondition(
+		t,
+		status,
+		conditionTypeUpgrading,
+		metav1.ConditionFalse,
+		reasonUpgradeComplete,
+	)
+}

--- a/internal/controller/test_constants_test.go
+++ b/internal/controller/test_constants_test.go
@@ -20,10 +20,13 @@ const (
 	testRuntimeRepository        = "ghcr.io/trussiumhq/trussium"
 	testRuntimeTag               = "0.23.0"
 	testRuntimeImage             = testRuntimeRepository + ":" + testRuntimeTag
+	testUpgradeRuntimeTag        = "0.24.0"
+	testUpgradeRuntimeImage      = testRuntimeRepository + ":" + testUpgradeRuntimeTag
 	testRuntimeNamespace         = runtimeContainerName
 	testImagePullSecret          = "ghcr-credentials"
 	testProviderCredentialSecret = "provider-credentials"
 	testProviderCredentialKey    = "api-key"
 	testRuntimeEndpoint          = "http://production.trussium.svc.cluster.local:9000"
 	testRuntimeReadyMessage      = "The runtime is ready."
+	testProviderName             = "ollama"
 )


### PR DESCRIPTION
# PR Description

Closes #18

## Summary

Implements the runtime upgrade lifecycle and compatibility reporting for `TrussiumRuntime`.

The operator now distinguishes initial deployment from runtime image upgrades, tracks desired and last-successful runtime images, observes Deployment rollout progress and failure, triggers configuration-driven rollouts through a deterministic checksum, and emits upgrade lifecycle Events.

This change preserves the existing `currentImage` status semantics and does not introduce direct Pod or ReplicaSet reads.

## Motivation

Before this change, runtime image updates were reconciled correctly but were not modeled as an explicit upgrade lifecycle.

Users and automation could not reliably determine:

- Whether a runtime image upgrade had started
- Which image was currently desired
- Which image had last completed successfully
- Whether a rollout was still progressing
- Whether an upgrade had completed
- Whether an upgrade had failed
- Whether a configuration change caused a Deployment rollout
- Which operator/runtime combinations are currently considered compatible

This pull request adds that observability while preserving the existing Kubernetes-native controller model.

## Changes

### Runtime Image Status

Added:

- `status.desiredImage`
- `status.lastSuccessfulImage`

Preserved the existing meaning of:

- `status.currentImage`

The resulting status model distinguishes:

- Requested runtime image
- Deployment-configured runtime image
- Last successfully rolled-out runtime image

Example during an upgrade:

    desiredImage: ghcr.io/trussiumhq/trussium:v0.24.0
    currentImage: ghcr.io/trussiumhq/trussium:v0.24.0
    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v0.23.0

After successful rollout completion:

    desiredImage: ghcr.io/trussiumhq/trussium:v0.24.0
    currentImage: ghcr.io/trussiumhq/trussium:v0.24.0
    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v0.24.0

### Initial Deployment Semantics

The first successful Deployment rollout establishes `lastSuccessfulImage`.

Initial runtime provisioning is not treated as an image upgrade.

Initial upgrade state is:

    type: Upgrading
    status: "False"
    reason: NoUpgrade

### Upgrading Condition

Added a new condition:

    Upgrading

Stable reasons include:

- `NoUpgrade`
- `UpgradeInProgress`
- `UpgradeComplete`
- `UpgradeFailed`

The condition complements the existing runtime conditions:

- `ConfigurationValid`
- `Progressing`
- `Available`
- `Ready`
- `Degraded`

### Upgrade Detection

An image transition is considered an upgrade only when:

1. `lastSuccessfulImage` is already established.
2. The desired image differs from `lastSuccessfulImage`.

This means configuration-only, metadata-only, scheduling-only, and other same-image Pod-template rollouts are not reported as runtime image upgrades.

Both image tags and image digests participate in the same lifecycle.

### Deployment Rollout Observation

Upgrade state is derived from the managed Deployment.

The controller observes:

- Deployment generation
- Deployment observed generation
- Desired replicas
- Total replicas
- Updated replicas
- Ready replicas
- Available replicas
- Unavailable replicas
- Deployment `Progressing` condition
- Deployment `ReplicaFailure` condition

No Pod or ReplicaSet reads are required.

### Rollout Completion

For desired replicas greater than zero, rollout completion requires:

- Deployment observed generation is current
- Updated replicas equal desired replicas
- Total replicas equal desired replicas
- Ready replicas equal desired replicas
- Available replicas equal desired replicas
- Unavailable replicas equal zero

This prevents upgrade completion from being reported while older replicas are still present.

### Scale-to-Zero Upgrade Semantics

Image upgrades remain valid for:

    spec.replicas: 0

A zero-replica rollout completes when the Deployment has observed its current generation and all replica counts are zero.

The operator does not start a Pod merely to establish an image upgrade state.

### Rollout Failure

Upgrade failures are detected from standard Deployment status.

Supported failure signals include:

- `Progressing=False` with `ProgressDeadlineExceeded`
- `ReplicaFailure=True`

When an image upgrade fails:

- `Upgrading=False`
- `Upgrading.reason=UpgradeFailed`
- `Ready=False`
- `Degraded=True`
- `lastSuccessfulImage` remains unchanged
- `desiredImage` continues to report the requested image

The operator does not automatically roll back.

### Deployment Progress Deadline

Managed Deployments now explicitly use:

    progressDeadlineSeconds: 600

This gives Kubernetes a deterministic mechanism for reporting stalled rollout progress.

### Configuration-Triggered Rollouts

Added a deterministic Pod-template checksum annotation:

    runtime.trussium.io/config-checksum

The checksum is derived from the fully rendered operator-managed ConfigMap data.

The implementation:

- Uses SHA-256
- Sorts keys deterministically
- Produces stable output independent of Go map iteration order
- Changes when projected runtime configuration changes
- Remains unchanged for semantically identical configuration

This ensures ConfigMap changes trigger normal Deployment revisions.

### Checksum Security Boundary

The runtime configuration checksum excludes:

- Secret values
- Secret contents
- Secret resource versions
- Object timestamps
- Random values
- Kubernetes resource versions

Provider credential Secret values are never read for checksum calculation.

### Upgrade Lifecycle Events

Added:

Normal Events:

- `RuntimeUpgradeStarted`
- `RuntimeUpgradeCompleted`

Warning Event:

- `RuntimeUpgradeFailed`

Upgrade Events include the previous successful image and desired image where applicable.

They are emitted only for lifecycle transitions.

Initial deployment does not emit `RuntimeUpgradeStarted`.

Repeated reconciliation with unchanged upgrade state does not emit duplicate upgrade Events.

### Upgrade State Preservation

A successful upgrade remains:

    Upgrading=False
    reason=UpgradeComplete

during unchanged reconciliation rather than immediately reverting to `NoUpgrade`.

This preserves the most recent upgrade outcome in status.

### Compatibility Contract

Added pre-release operator/runtime compatibility documentation.

The compatibility model now distinguishes:

- Operator version
- Runtime image identity
- Kubernetes API expectations
- Runtime health contract
- Runtime configuration contract
- Runtime container security contract

Current pre-release compatibility is documented without inventing unsupported version guarantees.

The operator does not currently reject images based on:

- Semantic version
- Tag format
- Digest
- Registry
- Runtime release metadata

### RBAC

No new permissions were added for:

- Pods
- ReplicaSets
- Nodes
- Secret values

Existing Deployment access is sufficient for rollout observation.

### Testing

Added or expanded coverage for:

- Desired image reporting
- Initial empty `lastSuccessfulImage`
- Initial successful image establishment
- Initial deployment not classified as upgrade
- Upgrade detection
- Upgrade progression
- Successful upgrade completion
- Upgrade-complete state preservation
- Failed upgrade handling
- Last-successful-image preservation after failure
- Same-image configuration rollout
- Scale-to-zero image upgrade
- Deployment generation pending
- Updated replica convergence
- Total replica convergence
- Ready replica convergence
- Available replica convergence
- Unavailable replica handling
- Progress deadline failure
- Replica failure
- Stable runtime configuration checksum
- Checksum changes after configuration change
- Map-order-independent checksum
- Operator-owned checksum annotation
- Configuration-triggered Pod template change
- Upgrade-start Event
- Upgrade-complete Event
- Upgrade-failed Event
- Initial deployment Event suppression
- Duplicate upgrade Event prevention
- Source and destination image content in Events

### Documentation

Added:

- `docs/UPGRADES.md`
- `docs/COMPATIBILITY.md`
- `docs/adr/0007-observe-upgrades-through-deployment-status.md`

Updated:

- `docs/STATUS_AND_EVENTS.md`
- `docs/RECONCILIATION.md`
- `docs/CUSTOM_RESOURCE.md`
- `docs/adr/README.md`
- `README.md`
- `ROADMAP.md`

Milestone O6 is now marked completed.

Milestone O7, controller integration and end-to-end testing, is now the next priority.

## Upgrade Lifecycle

The lifecycle is:

    Initial Deployment
            |
            v
    First Successful Rollout
            |
            v
    lastSuccessfulImage established
            |
            +-------------------------------+
            |                               |
            | same image                    | new desired image
            |                               |
            v                               v
    Upgrading=False                 Upgrading=True
    NoUpgrade                       UpgradeInProgress
                                            |
                              +-------------+-------------+
                              |                           |
                              v                           v
                         Rollout succeeds            Rollout fails
                              |                           |
                              v                           v
                     lastSuccessfulImage         lastSuccessfulImage
                     updated                     unchanged
                              |                           |
                              v                           v
                     Upgrading=False             Upgrading=False
                     UpgradeComplete             UpgradeFailed

## Scope Boundary

This pull request does not add:

- Automatic rollback
- Manual rollback API
- Direct Pod reads
- ReplicaSet reads
- Pod RBAC
- ReplicaSet RBAC
- Runtime HTTP probing by the controller
- Periodic rollout polling
- Semantic-version enforcement
- Runtime image admission policy
- Registry queries
- Signature verification
- Secret-value checksums
- Secret-content-triggered rollouts
- Upgrade waves
- Maintenance windows
- Multi-cluster rollout coordination
- Admission webhooks
- Conversion webhooks
- Helm packaging
- Operator image publication

These remain assigned to later milestones or higher-level control-plane capabilities.

## Security

- Secret values are never included in configuration checksums.
- Secret contents are never read for upgrade tracking.
- Upgrade Events never include Secret values.
- No Pod permissions are introduced.
- No ReplicaSet permissions are introduced.
- The controller continues to rely on Deployment status as the rollout source of truth.
- Failed upgrades do not silently mutate desired state.
- Automatic rollback is intentionally not implemented.

## Compatibility

- **API compatibility:** Existing `v1alpha1` resources remain valid.
- **Status compatibility:** New status fields and the `Upgrading` condition are additive.
- **Runtime compatibility:** Upgrade tracking operates on complete image references and does not require semantic-version parsing.
- **Kubernetes compatibility:** Uses standard Deployment rollout state and conditions.
- **Go module:** Remains `github.com/trussiumhq/trussium-operator`.
- **Canonical runtime image:** Remains `ghcr.io/trussiumhq/trussium`.

## Validation

The following commands pass:

    go mod tidy
    go mod verify

    make generate
    make manifests
    make fmt
    make vet
    make test
    make lint

    go test ./api/v1alpha1 -v
    go test ./internal/controller -v
    go build ./cmd/...

Generated artifacts remain stable:

    git add -A

    make generate
    make manifests
    make fmt

    git diff --exit-code
    git diff --cached --check

RBAC was verified to contain:

- No Pod permissions
- No ReplicaSet permissions
- Existing Deployment permissions only for rollout observation
- Existing Events permissions for lifecycle Events

## Checklist

- [x] The change is scoped to the linked issue.
- [x] The Go module remains `github.com/trussiumhq/trussium-operator`.
- [x] Canonical runtime image remains `ghcr.io/trussiumhq/trussium`.
- [x] Existing `v1alpha1` resources remain valid.
- [x] Status API changes are additive.
- [x] `desiredImage` is reported.
- [x] Existing `currentImage` semantics are preserved.
- [x] `lastSuccessfulImage` is reported.
- [x] Initial deployment is not classified as an upgrade.
- [x] First successful rollout establishes `lastSuccessfulImage`.
- [x] Same-image configuration rollout is not classified as an image upgrade.
- [x] Image changes are classified as upgrades.
- [x] Tag-based image changes are supported.
- [x] Digest-based image identities are supported.
- [x] `Upgrading` condition is implemented.
- [x] `NoUpgrade` reason is implemented.
- [x] `UpgradeInProgress` reason is implemented.
- [x] `UpgradeComplete` reason is implemented.
- [x] `UpgradeFailed` reason is implemented.
- [x] Upgrade-complete status is preserved on unchanged reconciliation.
- [x] Deployment generation is observed.
- [x] Updated replicas are observed.
- [x] Total replicas are observed.
- [x] Ready replicas are observed.
- [x] Available replicas are observed.
- [x] Unavailable replicas are observed.
- [x] Rollout completion is detected.
- [x] `ProgressDeadlineExceeded` is detected.
- [x] Replica failure is detected.
- [x] Scale-to-zero upgrades are supported.
- [x] Failed upgrades preserve `lastSuccessfulImage`.
- [x] Automatic rollback is not implemented.
- [x] `progressDeadlineSeconds: 600` is configured.
- [x] Deterministic runtime configuration checksum is implemented.
- [x] SHA-256 is used for the checksum.
- [x] Checksum is independent of map iteration order.
- [x] Configuration change triggers Deployment Pod-template change.
- [x] Secret values are excluded from checksums.
- [x] Checksum annotation remains operator-owned.
- [x] `RuntimeUpgradeStarted` Event is implemented.
- [x] `RuntimeUpgradeCompleted` Event is implemented.
- [x] `RuntimeUpgradeFailed` Event is implemented.
- [x] Initial deployment emits no upgrade-start Event.
- [x] Duplicate upgrade Events are prevented.
- [x] Upgrade Events include source and destination image identity.
- [x] No Pod RBAC is introduced.
- [x] No ReplicaSet RBAC is introduced.
- [x] No rollout polling is introduced.
- [x] Compatibility documentation is added.
- [x] No unsupported compatibility guarantees are invented.
- [x] Upgrade lifecycle documentation is added.
- [x] ADR 0007 is added.
- [x] Unit tests pass.
- [x] Controller tests pass.
- [x] API tests pass.
- [x] Go vet passes.
- [x] Lint passes.
- [x] Generated manifests are stable.
- [x] Documentation is updated.
- [x] Roadmap Milestone O6 is completed.
- [x] Milestone O7 is identified as the next priority.