### PR TITLE
test: add controller integration and end-to-end coverage

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -36,3 +36,14 @@ jobs:
         run: |
           go mod tidy
           make test-e2e
+
+      - name: Collect E2E diagnostics on failure
+        if: failure()
+        env:
+          KUBECONFIG: ${{ github.workspace }}/bin/trussium-operator-test-e2e.kubeconfig
+        run: |
+          kubectl get all -A || true
+          kubectl get trussiumruntimes -A -o yaml || true
+          kubectl get events -A --sort-by=.lastTimestamp || true
+          kubectl describe deployments -A || true
+          kubectl describe pods -A || true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,11 +67,20 @@ make lint
 make test
 ```
 
-The project will eventually use:
+The project uses:
 
 - Standard Go tests for pure resource builders
 - envtest for controller integration tests
 - Kind for real-cluster end-to-end tests
+
+Run the complete Kind suite with:
+
+```bash
+make test-e2e
+```
+
+This target creates an isolated Kind cluster, builds and side-loads the
+operator image, runs the E2E suite, and removes the cluster afterward.
 
 ## Complete Validation
 
@@ -82,6 +91,7 @@ make fmt
 make vet
 make test
 make lint
+make test-e2e
 ```
 
 Before committing, stage the intended files and verify generation stability:

--- a/Makefile
+++ b/Makefile
@@ -67,9 +67,10 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # kubectl kuberc is disabled by default for test isolation; enable with:
 # - KUBECTL_KUBERC=true
-# CertManager is installed by default; skip with:
-# - CERT_MANAGER_INSTALL_SKIP=true
+# CertManager is not required by the current Trussium Operator E2E suite because
+# admission/conversion webhooks are outside the current test scope.
 KIND_CLUSTER ?= trussium-operator-test-e2e
+KIND_KUBECONFIG ?= $(LOCALBIN)/$(KIND_CLUSTER).kubeconfig
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
@@ -82,17 +83,19 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
 		*) \
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
+			$(KIND) create cluster --name $(KIND_CLUSTER) --kubeconfig $(KIND_KUBECONFIG) ;; \
 	esac
+	@$(KIND) export kubeconfig --name $(KIND_CLUSTER) --kubeconfig $(KIND_KUBECONFIG)
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
-	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
+	KUBECONFIG=$(KIND_KUBECONFIG) KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) CERT_MANAGER_INSTALL_SKIP=true go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests
 	@$(KIND) delete cluster --name $(KIND_CLUSTER)
+	@rm -f $(KIND_KUBECONFIG)
 
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Run:
     make vet
     make test
     make lint
+    make test-e2e
 
 ## Runtime Upgrades
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -380,7 +380,7 @@ unsupported version guarantees.
 
 ## Milestone O7 — Controller and End-to-End Testing
 
-**Status:** 🗓 Planned
+**Status:** ✅ Complete
 
 Validate the controller against Kubernetes API machinery and real clusters.
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -1,2 +1,8 @@
 resources:
 - manager.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: controller
+  newName: example.com/trussium-operator
+  newTag: v0.0.1

--- a/internal/controller/integration/events_test.go
+++ b/internal/controller/integration/events_test.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	eventsv1 "k8s.io/api/events/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+const (
+	runtimeUpgradeStartedEvent   = "RuntimeUpgradeStarted"
+	runtimeUpgradeCompletedEvent = "RuntimeUpgradeCompleted"
+	runtimeUpgradeFailedEvent    = "RuntimeUpgradeFailed"
+	runtimeScaledToZeroEvent     = "RuntimeScaledToZero"
+)
+
+func TestUpgradeLifecyclePersistsKubernetesEvents(
+	t *testing.T,
+) {
+	t.Run(
+		"successful upgrade persists started and completed events",
+		func(t *testing.T) {
+			fixture :=
+				establishSuccessfulRuntime(t)
+
+			previousGeneration :=
+				fixture.Deployment.Generation
+
+			updateRuntimeImageTag(
+				t,
+				fixture.Key,
+			)
+
+			waitForDeploymentImage(
+				t,
+				fixture.Key,
+				previousGeneration,
+			)
+
+			waitForUpgradeConditionState(
+				t,
+				fixture.Key,
+				metav1.ConditionTrue,
+				upgradeInProgressReason,
+			)
+
+			waitForRuntimeEventReason(
+				t,
+				fixture.Key,
+				fixture.Runtime.UID,
+				runtimeUpgradeStartedEvent,
+			)
+
+			markDeploymentRolloutComplete(
+				t,
+				fixture.Key,
+			)
+
+			waitForUpgradeConditionState(
+				t,
+				fixture.Key,
+				metav1.ConditionFalse,
+				upgradeCompleteReason,
+			)
+
+			waitForRuntimeEventReason(
+				t,
+				fixture.Key,
+				fixture.Runtime.UID,
+				runtimeUpgradeCompletedEvent,
+			)
+		},
+	)
+
+	t.Run(
+		"failed upgrade persists failure event",
+		func(t *testing.T) {
+			fixture :=
+				establishSuccessfulRuntime(t)
+
+			previousGeneration :=
+				fixture.Deployment.Generation
+
+			updateRuntimeImageTag(
+				t,
+				fixture.Key,
+			)
+
+			waitForDeploymentImage(
+				t,
+				fixture.Key,
+				previousGeneration,
+			)
+
+			waitForUpgradeConditionState(
+				t,
+				fixture.Key,
+				metav1.ConditionTrue,
+				upgradeInProgressReason,
+			)
+
+			waitForRuntimeEventReason(
+				t,
+				fixture.Key,
+				fixture.Runtime.UID,
+				runtimeUpgradeStartedEvent,
+			)
+
+			markDeploymentRolloutFailed(
+				t,
+				fixture.Key,
+			)
+
+			waitForUpgradeConditionState(
+				t,
+				fixture.Key,
+				metav1.ConditionFalse,
+				upgradeFailedReason,
+			)
+
+			waitForRuntimeEventReason(
+				t,
+				fixture.Key,
+				fixture.Runtime.UID,
+				runtimeUpgradeFailedEvent,
+			)
+		},
+	)
+}
+
+func TestScaleToZeroPersistsKubernetesEvent(
+	t *testing.T,
+) {
+	fixture := establishSuccessfulRuntime(t)
+
+	updateRuntimeReplicas(
+		t,
+		fixture.Key,
+		0,
+	)
+
+	waitForDeploymentReplicas(
+		t,
+		fixture.Key,
+		0,
+	)
+
+	markDeploymentScaledToZero(
+		t,
+		fixture.Key,
+	)
+
+	waitForRuntimeStatus(
+		t,
+		fixture.Key,
+		func(
+			runtimeResource *runtimev1alpha1.TrussiumRuntime,
+		) bool {
+			progressing := runtimeCondition(
+				runtimeResource,
+				"Progressing",
+			)
+
+			return runtimeResource.Status.ObservedGeneration ==
+				runtimeResource.Generation &&
+				runtimeResource.Status.ReadyReplicas == 0 &&
+				runtimeResource.Status.AvailableReplicas == 0 &&
+				progressing != nil &&
+				progressing.Status == metav1.ConditionFalse &&
+				progressing.Reason == scaledToZeroReason
+		},
+	)
+
+	waitForRuntimeEventReason(
+		t,
+		fixture.Key,
+		fixture.Runtime.UID,
+		runtimeScaledToZeroEvent,
+	)
+}
+
+func waitForRuntimeEventReason(
+	t *testing.T,
+	key client.ObjectKey,
+	runtimeUID types.UID,
+	reason string,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"Kubernetes Event "+reason,
+		func() (bool, error) {
+			var events eventsv1.EventList
+
+			if err := testClient.List(
+				context.Background(),
+				&events,
+				client.InNamespace(key.Namespace),
+			); err != nil {
+				return false, err
+			}
+
+			for index := range events.Items {
+				event := &events.Items[index]
+
+				if event.Reason != reason {
+					continue
+				}
+
+				if event.Regarding.Name != key.Name {
+					continue
+				}
+
+				if event.Regarding.Namespace !=
+					key.Namespace {
+					continue
+				}
+
+				if event.Regarding.UID != runtimeUID {
+					continue
+				}
+
+				if event.Regarding.Kind !=
+					"TrussiumRuntime" {
+					continue
+				}
+
+				return true, nil
+			}
+
+			return false, nil
+		},
+	)
+}

--- a/internal/controller/integration/fixtures_test.go
+++ b/internal/controller/integration/fixtures_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+const (
+	testRuntimeImageRepository = "ghcr.io/trussiumhq/trussium"
+	testRuntimeImageTag        = "0.23.0"
+	testRuntimeModel           = "llama3.2"
+)
+
+func createTestNamespace(
+	t *testing.T,
+) *corev1.Namespace {
+	t.Helper()
+
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "trussium-integration-",
+		},
+	}
+
+	if err := testClient.Create(
+		context.Background(),
+		namespace,
+	); err != nil {
+		t.Fatalf("create integration namespace: %v", err)
+	}
+
+	return namespace
+}
+
+func createTestRuntime(
+	t *testing.T,
+	namespace string,
+) *runtimev1alpha1.TrussiumRuntime {
+	t.Helper()
+
+	replicas := int32(1)
+	tag := testRuntimeImageTag
+
+	runtimeResource := &runtimev1alpha1.TrussiumRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runtime",
+			Namespace: namespace,
+		},
+		Spec: runtimev1alpha1.TrussiumRuntimeSpec{
+			Image: runtimev1alpha1.RuntimeImageSpec{
+				Repository: testRuntimeImageRepository,
+				Tag:        &tag,
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			Replicas: &replicas,
+			Provider: runtimev1alpha1.ProviderSpec{
+				Type:  runtimev1alpha1.ProviderTypeOllama,
+				Model: testRuntimeModel,
+			},
+			Service: runtimev1alpha1.RuntimeServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Port: 9000,
+			},
+		},
+	}
+
+	if err := testClient.Create(
+		context.Background(),
+		runtimeResource,
+	); err != nil {
+		t.Fatalf("create TrussiumRuntime: %v", err)
+	}
+
+	return runtimeResource
+}
+
+func waitForObject[T client.Object](
+	t *testing.T,
+	key client.ObjectKey,
+	object T,
+) T {
+	t.Helper()
+
+	eventually(
+		t,
+		fmt.Sprintf("%T %s", object, key.String()),
+		func() (bool, error) {
+			err := testClient.Get(
+				context.Background(),
+				key,
+				object,
+			)
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+
+			if err != nil {
+				return false, err
+			}
+
+			return true, nil
+		},
+	)
+
+	return object
+}
+
+func waitForRuntimeStatus(
+	t *testing.T,
+	key client.ObjectKey,
+	condition func(
+		*runtimev1alpha1.TrussiumRuntime,
+	) bool,
+) *runtimev1alpha1.TrussiumRuntime {
+	t.Helper()
+
+	var current runtimev1alpha1.TrussiumRuntime
+
+	eventually(
+		t,
+		fmt.Sprintf(
+			"TrussiumRuntime status %s",
+			key.String(),
+		),
+		func() (bool, error) {
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&current,
+			); err != nil {
+				return false, err
+			}
+
+			return condition(&current), nil
+		},
+	)
+
+	return current.DeepCopy()
+}
+
+func eventually(
+	t *testing.T,
+	description string,
+	condition func() (bool, error),
+) {
+	t.Helper()
+
+	deadline := time.Now().Add(integrationTimeout)
+
+	var lastError error
+
+	for time.Now().Before(deadline) {
+		done, err := condition()
+		if err != nil {
+			lastError = err
+		} else if done {
+			return
+		}
+
+		time.Sleep(integrationPollInterval)
+	}
+
+	if lastError != nil {
+		t.Fatalf(
+			"timed out waiting for %s: %v",
+			description,
+			lastError,
+		)
+	}
+
+	t.Fatalf(
+		"timed out waiting for %s",
+		description,
+	)
+}
+
+func assertControllerOwner(
+	t *testing.T,
+	child metav1.Object,
+	owner *runtimev1alpha1.TrussiumRuntime,
+) {
+	t.Helper()
+
+	for _, reference := range child.GetOwnerReferences() {
+		if reference.UID != owner.UID {
+			continue
+		}
+
+		if reference.Controller == nil ||
+			!*reference.Controller {
+			t.Fatalf(
+				"%T %s/%s owner reference for %s is not a controller reference",
+				child,
+				child.GetNamespace(),
+				child.GetName(),
+				owner.Name,
+			)
+		}
+
+		if reference.APIVersion != runtimev1alpha1.GroupVersion.String() {
+			t.Fatalf(
+				"%T %s/%s has owner apiVersion %q, expected %q",
+				child,
+				child.GetNamespace(),
+				child.GetName(),
+				reference.APIVersion,
+				runtimev1alpha1.GroupVersion.String(),
+			)
+		}
+
+		if reference.Kind != "TrussiumRuntime" {
+			t.Fatalf(
+				"%T %s/%s has owner kind %q, expected TrussiumRuntime",
+				child,
+				child.GetNamespace(),
+				child.GetName(),
+				reference.Kind,
+			)
+		}
+
+		return
+	}
+
+	t.Fatalf(
+		"%T %s/%s is not controlled by TrussiumRuntime %s/%s",
+		child,
+		child.GetNamespace(),
+		child.GetName(),
+		owner.Namespace,
+		owner.Name,
+	)
+}
+
+func runtimeCondition(
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	conditionType string,
+) *metav1.Condition {
+	return meta.FindStatusCondition(
+		runtimeResource.Status.Conditions,
+		conditionType,
+	)
+}

--- a/internal/controller/integration/reconciliation_test.go
+++ b/internal/controller/integration/reconciliation_test.go
@@ -1,0 +1,518 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+func TestManagerReconcilesTrussiumRuntime(
+	t *testing.T,
+) {
+	namespace := createTestNamespace(t)
+
+	runtimeResource := createTestRuntime(
+		t,
+		namespace.Name,
+	)
+
+	key := client.ObjectKey{
+		Name:      runtimeResource.Name,
+		Namespace: runtimeResource.Namespace,
+	}
+
+	configMap := waitForObject(
+		t,
+		key,
+		&corev1.ConfigMap{},
+	)
+
+	serviceAccount := waitForObject(
+		t,
+		key,
+		&corev1.ServiceAccount{},
+	)
+
+	service := waitForObject(
+		t,
+		key,
+		&corev1.Service{},
+	)
+
+	deployment := waitForObject(
+		t,
+		key,
+		&appsv1.Deployment{},
+	)
+
+	podDisruptionBudget := waitForObject(
+		t,
+		key,
+		&policyv1.PodDisruptionBudget{},
+	)
+
+	t.Run(
+		"creates the managed Kubernetes resources",
+		func(t *testing.T) {
+			assertManagedResources(
+				t,
+				configMap,
+				serviceAccount,
+				service,
+				deployment,
+				podDisruptionBudget,
+			)
+		},
+	)
+
+	t.Run(
+		"sets controller ownership on managed resources",
+		func(t *testing.T) {
+			assertManagedResourceOwnership(
+				t,
+				runtimeResource,
+				configMap,
+				serviceAccount,
+				service,
+				deployment,
+				podDisruptionBudget,
+			)
+		},
+	)
+
+	t.Run(
+		"persists observed state through the status subresource",
+		func(t *testing.T) {
+			assertRuntimeObservedStatus(
+				t,
+				key,
+				namespace.Name,
+			)
+		},
+	)
+}
+
+func assertManagedResources(
+	t *testing.T,
+	configMap *corev1.ConfigMap,
+	serviceAccount *corev1.ServiceAccount,
+	service *corev1.Service,
+	deployment *appsv1.Deployment,
+	podDisruptionBudget *policyv1.PodDisruptionBudget,
+) {
+	t.Helper()
+
+	assertManagedConfigMap(
+		t,
+		configMap,
+	)
+
+	assertManagedServiceAccount(
+		t,
+		serviceAccount,
+	)
+
+	assertManagedService(
+		t,
+		service,
+	)
+
+	assertManagedDeployment(
+		t,
+		deployment,
+	)
+
+	assertManagedPodDisruptionBudget(
+		t,
+		podDisruptionBudget,
+	)
+}
+
+func assertManagedConfigMap(
+	t *testing.T,
+	configMap *corev1.ConfigMap,
+) {
+	t.Helper()
+
+	if got := configMap.Data["TRUSSIUM_ENVIRONMENT"]; got != "production" {
+		t.Fatalf(
+			"ConfigMap TRUSSIUM_ENVIRONMENT = %q, expected production",
+			got,
+		)
+	}
+
+	if got := configMap.Data["TRUSSIUM_RUNTIME__PORT"]; got != "9000" {
+		t.Fatalf(
+			"ConfigMap TRUSSIUM_RUNTIME__PORT = %q, expected 9000",
+			got,
+		)
+	}
+
+	if got := configMap.Data["TRUSSIUM_PROVIDER__NAME"]; got != "ollama" {
+		t.Fatalf(
+			"ConfigMap TRUSSIUM_PROVIDER__NAME = %q, expected ollama",
+			got,
+		)
+	}
+}
+
+func assertManagedServiceAccount(
+	t *testing.T,
+	serviceAccount *corev1.ServiceAccount,
+) {
+	t.Helper()
+
+	if serviceAccount.AutomountServiceAccountToken == nil {
+		t.Fatal(
+			"ServiceAccount automountServiceAccountToken must be set",
+		)
+	}
+
+	if *serviceAccount.AutomountServiceAccountToken {
+		t.Fatal(
+			"ServiceAccount must disable automountServiceAccountToken",
+		)
+	}
+}
+
+func assertManagedService(
+	t *testing.T,
+	service *corev1.Service,
+) {
+	t.Helper()
+
+	if service.Spec.Type != corev1.ServiceTypeClusterIP {
+		t.Fatalf(
+			"Service type = %q, expected ClusterIP",
+			service.Spec.Type,
+		)
+	}
+
+	if len(service.Spec.Ports) != 1 {
+		t.Fatalf(
+			"Service has %d ports, expected 1",
+			len(service.Spec.Ports),
+		)
+	}
+
+	if service.Spec.Ports[0].Port != 9000 {
+		t.Fatalf(
+			"Service port = %d, expected 9000",
+			service.Spec.Ports[0].Port,
+		)
+	}
+}
+
+func assertManagedDeployment(
+	t *testing.T,
+	deployment *appsv1.Deployment,
+) {
+	t.Helper()
+
+	if deployment.Spec.Replicas == nil {
+		t.Fatal(
+			"Deployment replicas must be set",
+		)
+	}
+
+	if *deployment.Spec.Replicas != 1 {
+		t.Fatalf(
+			"Deployment replicas = %d, expected 1",
+			*deployment.Spec.Replicas,
+		)
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf(
+			"Deployment has %d containers, expected 1",
+			len(deployment.Spec.Template.Spec.Containers),
+		)
+	}
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	if container.Name != "trussium" {
+		t.Fatalf(
+			"runtime container name = %q, expected trussium",
+			container.Name,
+		)
+	}
+
+	expectedImage :=
+		testRuntimeImageRepository + ":" + testRuntimeImageTag
+
+	if container.Image != expectedImage {
+		t.Fatalf(
+			"runtime container image = %q, expected %q",
+			container.Image,
+			expectedImage,
+		)
+	}
+}
+
+func assertManagedPodDisruptionBudget(
+	t *testing.T,
+	podDisruptionBudget *policyv1.PodDisruptionBudget,
+) {
+	t.Helper()
+
+	if podDisruptionBudget.Spec.Selector == nil {
+		t.Fatal(
+			"PodDisruptionBudget must define a selector",
+		)
+	}
+}
+
+func assertManagedResourceOwnership(
+	t *testing.T,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	configMap *corev1.ConfigMap,
+	serviceAccount *corev1.ServiceAccount,
+	service *corev1.Service,
+	deployment *appsv1.Deployment,
+	podDisruptionBudget *policyv1.PodDisruptionBudget,
+) {
+	t.Helper()
+
+	assertControllerOwner(
+		t,
+		configMap,
+		runtimeResource,
+	)
+
+	assertControllerOwner(
+		t,
+		serviceAccount,
+		runtimeResource,
+	)
+
+	assertControllerOwner(
+		t,
+		service,
+		runtimeResource,
+	)
+
+	assertControllerOwner(
+		t,
+		deployment,
+		runtimeResource,
+	)
+
+	assertControllerOwner(
+		t,
+		podDisruptionBudget,
+		runtimeResource,
+	)
+}
+
+func assertRuntimeObservedStatus(
+	t *testing.T,
+	key client.ObjectKey,
+	namespace string,
+) {
+	t.Helper()
+
+	expectedImage :=
+		testRuntimeImageRepository + ":" + testRuntimeImageTag
+
+	expectedEndpoint :=
+		"http://runtime." +
+			namespace +
+			".svc.cluster.local:9000"
+
+	current := waitForRuntimeStatus(
+		t,
+		key,
+		func(
+			runtimeStatus *runtimev1alpha1.TrussiumRuntime,
+		) bool {
+			return runtimeStatus.Status.ObservedGeneration ==
+				runtimeStatus.Generation &&
+				runtimeStatus.Status.DesiredImage ==
+					expectedImage &&
+				runtimeStatus.Status.CurrentImage ==
+					expectedImage &&
+				runtimeStatus.Status.Endpoint ==
+					expectedEndpoint &&
+				runtimeCondition(
+					runtimeStatus,
+					"ConfigurationValid",
+				) != nil
+		},
+	)
+
+	assertRuntimeStatusValues(
+		t,
+		current,
+		expectedImage,
+		expectedEndpoint,
+	)
+
+	assertConfigurationValidCondition(
+		t,
+		current,
+	)
+
+	assertProgressingCondition(
+		t,
+		current,
+	)
+
+	assertReadyCondition(
+		t,
+		current,
+	)
+}
+
+func assertRuntimeStatusValues(
+	t *testing.T,
+	current *runtimev1alpha1.TrussiumRuntime,
+	expectedImage string,
+	expectedEndpoint string,
+) {
+	t.Helper()
+
+	if current.Status.ObservedGeneration != current.Generation {
+		t.Fatalf(
+			"status observedGeneration = %d, expected generation %d",
+			current.Status.ObservedGeneration,
+			current.Generation,
+		)
+	}
+
+	if current.Status.DesiredImage != expectedImage {
+		t.Fatalf(
+			"status desiredImage = %q, expected %q",
+			current.Status.DesiredImage,
+			expectedImage,
+		)
+	}
+
+	if current.Status.CurrentImage != expectedImage {
+		t.Fatalf(
+			"status currentImage = %q, expected %q",
+			current.Status.CurrentImage,
+			expectedImage,
+		)
+	}
+
+	if current.Status.Endpoint != expectedEndpoint {
+		t.Fatalf(
+			"status endpoint = %q, expected %q",
+			current.Status.Endpoint,
+			expectedEndpoint,
+		)
+	}
+}
+
+func assertConfigurationValidCondition(
+	t *testing.T,
+	current *runtimev1alpha1.TrussiumRuntime,
+) {
+	t.Helper()
+
+	condition := runtimeCondition(
+		current,
+		"ConfigurationValid",
+	)
+
+	if condition == nil {
+		t.Fatal(
+			"ConfigurationValid condition was not persisted",
+		)
+	}
+
+	if condition.Status != metav1.ConditionTrue {
+		t.Fatalf(
+			"ConfigurationValid status = %q, expected True",
+			condition.Status,
+		)
+	}
+
+	if condition.Reason != "ReferencesResolved" {
+		t.Fatalf(
+			"ConfigurationValid reason = %q, expected ReferencesResolved",
+			condition.Reason,
+		)
+	}
+
+	if condition.ObservedGeneration != current.Generation {
+		t.Fatalf(
+			"ConfigurationValid observedGeneration = %d, expected %d",
+			condition.ObservedGeneration,
+			current.Generation,
+		)
+	}
+}
+
+func assertProgressingCondition(
+	t *testing.T,
+	current *runtimev1alpha1.TrussiumRuntime,
+) {
+	t.Helper()
+
+	condition := runtimeCondition(
+		current,
+		"Progressing",
+	)
+
+	if condition == nil {
+		t.Fatal(
+			"Progressing condition was not persisted",
+		)
+	}
+
+	if condition.Status != metav1.ConditionTrue {
+		t.Fatalf(
+			"Progressing status = %q, expected True",
+			condition.Status,
+		)
+	}
+}
+
+func assertReadyCondition(
+	t *testing.T,
+	current *runtimev1alpha1.TrussiumRuntime,
+) {
+	t.Helper()
+
+	condition := runtimeCondition(
+		current,
+		"Ready",
+	)
+
+	if condition == nil {
+		t.Fatal(
+			"Ready condition was not persisted",
+		)
+	}
+
+	if condition.Status != metav1.ConditionFalse {
+		t.Fatalf(
+			"Ready status = %q, expected False",
+			condition.Status,
+		)
+	}
+}

--- a/internal/controller/integration/reference_recovery_test.go
+++ b/internal/controller/integration/reference_recovery_test.go
@@ -1,0 +1,489 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+const (
+	testProviderSecretName    = "provider-credentials"
+	testProviderSecretKey     = "api-key"
+	testImagePullSecretName   = "registry-credentials"
+	configurationValidType    = "ConfigurationValid"
+	secretNotFoundReason      = "SecretNotFound"
+	referencesResolvedReason  = "ReferencesResolved"
+	providerAPIKeyEnvironment = "TRUSSIUM_PROVIDER__API_KEY"
+)
+
+func TestProviderSecretReferenceRecovery(
+	t *testing.T,
+) {
+	namespace := createTestNamespace(t)
+
+	runtimeResource := createRuntimeWithSecretReferences(
+		t,
+		namespace.Name,
+		&runtimev1alpha1.SecretKeyReference{
+			Name: testProviderSecretName,
+			Key:  testProviderSecretKey,
+		},
+		nil,
+	)
+
+	key := client.ObjectKeyFromObject(runtimeResource)
+	initialGeneration := runtimeResource.Generation
+
+	invalidRuntime := waitForConfigurationValidConditionState(
+		t,
+		key,
+		metav1.ConditionFalse,
+		secretNotFoundReason,
+	)
+
+	assertMissingSecretMessage(
+		t,
+		invalidRuntime,
+		testProviderSecretName,
+	)
+
+	assertManagedDeploymentAbsent(
+		t,
+		key,
+	)
+
+	createTestSecret(
+		t,
+		namespace.Name,
+		testProviderSecretName,
+		corev1.SecretTypeOpaque,
+		map[string][]byte{
+			testProviderSecretKey: []byte("integration-test-api-key"),
+		},
+	)
+
+	recoveredRuntime := waitForConfigurationValidConditionState(
+		t,
+		key,
+		metav1.ConditionTrue,
+		referencesResolvedReason,
+	)
+
+	assertRuntimeGenerationUnchanged(
+		t,
+		recoveredRuntime,
+		initialGeneration,
+	)
+
+	deployment := waitForObject(
+		t,
+		key,
+		&appsv1.Deployment{},
+	)
+
+	assertProviderSecretProjection(
+		t,
+		deployment,
+		testProviderSecretName,
+		testProviderSecretKey,
+	)
+}
+
+func TestImagePullSecretReferenceRecovery(
+	t *testing.T,
+) {
+	namespace := createTestNamespace(t)
+
+	runtimeResource := createRuntimeWithSecretReferences(
+		t,
+		namespace.Name,
+		nil,
+		[]runtimev1alpha1.NamedReference{
+			{
+				Name: testImagePullSecretName,
+			},
+		},
+	)
+
+	key := client.ObjectKeyFromObject(runtimeResource)
+	initialGeneration := runtimeResource.Generation
+
+	invalidRuntime := waitForConfigurationValidConditionState(
+		t,
+		key,
+		metav1.ConditionFalse,
+		secretNotFoundReason,
+	)
+
+	assertMissingSecretMessage(
+		t,
+		invalidRuntime,
+		testImagePullSecretName,
+	)
+
+	assertManagedDeploymentAbsent(
+		t,
+		key,
+	)
+
+	createTestSecret(
+		t,
+		namespace.Name,
+		testImagePullSecretName,
+		corev1.SecretTypeDockerConfigJson,
+		map[string][]byte{
+			corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+		},
+	)
+
+	recoveredRuntime := waitForConfigurationValidConditionState(
+		t,
+		key,
+		metav1.ConditionTrue,
+		referencesResolvedReason,
+	)
+
+	assertRuntimeGenerationUnchanged(
+		t,
+		recoveredRuntime,
+		initialGeneration,
+	)
+
+	serviceAccount := waitForObject(
+		t,
+		key,
+		&corev1.ServiceAccount{},
+	)
+
+	deployment := waitForObject(
+		t,
+		key,
+		&appsv1.Deployment{},
+	)
+
+	assertImagePullSecretProjection(
+		t,
+		serviceAccount,
+		deployment,
+		testImagePullSecretName,
+	)
+}
+
+func createRuntimeWithSecretReferences(
+	t *testing.T,
+	namespace string,
+	credentialsSecretRef *runtimev1alpha1.SecretKeyReference,
+	imagePullSecrets []runtimev1alpha1.NamedReference,
+) *runtimev1alpha1.TrussiumRuntime {
+	t.Helper()
+
+	replicas := int32(1)
+	tag := testRuntimeImageTag
+
+	runtimeResource := &runtimev1alpha1.TrussiumRuntime{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "runtime",
+			Namespace: namespace,
+		},
+		Spec: runtimev1alpha1.TrussiumRuntimeSpec{
+			Image: runtimev1alpha1.RuntimeImageSpec{
+				Repository: testRuntimeImageRepository,
+				Tag:        &tag,
+				PullPolicy: corev1.PullIfNotPresent,
+			},
+			Replicas:         &replicas,
+			ImagePullSecrets: imagePullSecrets,
+			Provider: runtimev1alpha1.ProviderSpec{
+				Type:                 runtimev1alpha1.ProviderTypeOpenAI,
+				Model:                "gpt-4.1-mini",
+				CredentialsSecretRef: credentialsSecretRef,
+			},
+			Service: runtimev1alpha1.RuntimeServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Port: 9000,
+			},
+		},
+	}
+
+	if err := testClient.Create(
+		context.Background(),
+		runtimeResource,
+	); err != nil {
+		t.Fatalf(
+			"create TrussiumRuntime with Secret references: %v",
+			err,
+		)
+	}
+
+	return runtimeResource
+}
+
+func createTestSecret(
+	t *testing.T,
+	namespace string,
+	name string,
+	secretType corev1.SecretType,
+	data map[string][]byte,
+) {
+	t.Helper()
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Type: secretType,
+		Data: data,
+	}
+
+	if err := testClient.Create(
+		context.Background(),
+		secret,
+	); err != nil {
+		t.Fatalf(
+			"create Secret %s/%s: %v",
+			namespace,
+			name,
+			err,
+		)
+	}
+}
+
+func waitForConfigurationValidConditionState(
+	t *testing.T,
+	key client.ObjectKey,
+	status metav1.ConditionStatus,
+	reason string,
+) *runtimev1alpha1.TrussiumRuntime {
+	t.Helper()
+
+	return waitForRuntimeStatus(
+		t,
+		key,
+		func(
+			runtimeResource *runtimev1alpha1.TrussiumRuntime,
+		) bool {
+			condition := runtimeCondition(
+				runtimeResource,
+				configurationValidType,
+			)
+
+			return condition != nil &&
+				condition.Status == status &&
+				condition.Reason == reason
+		},
+	)
+}
+
+func assertMissingSecretMessage(
+	t *testing.T,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	secretName string,
+) {
+	t.Helper()
+
+	condition := runtimeCondition(
+		runtimeResource,
+		configurationValidType,
+	)
+	if condition == nil {
+		t.Fatal(
+			"ConfigurationValid condition was not persisted",
+		)
+	}
+
+	if !strings.Contains(
+		condition.Message,
+		secretName,
+	) {
+		t.Fatalf(
+			"ConfigurationValid message %q does not reference missing Secret %q",
+			condition.Message,
+			secretName,
+		)
+	}
+}
+
+func assertManagedDeploymentAbsent(
+	t *testing.T,
+	key client.ObjectKey,
+) {
+	t.Helper()
+
+	var deployment appsv1.Deployment
+
+	err := testClient.Get(
+		context.Background(),
+		key,
+		&deployment,
+	)
+
+	if err == nil {
+		t.Fatalf(
+			"Deployment %s unexpectedly exists while Secret reference is invalid",
+			key.String(),
+		)
+	}
+
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf(
+			"get Deployment %s while checking absence: %v",
+			key.String(),
+			err,
+		)
+	}
+}
+
+func assertRuntimeGenerationUnchanged(
+	t *testing.T,
+	runtimeResource *runtimev1alpha1.TrussiumRuntime,
+	expectedGeneration int64,
+) {
+	t.Helper()
+
+	if runtimeResource.Generation != expectedGeneration {
+		t.Fatalf(
+			"TrussiumRuntime generation changed from %d to %d during Secret recovery",
+			expectedGeneration,
+			runtimeResource.Generation,
+		)
+	}
+
+	if runtimeResource.Status.ObservedGeneration != expectedGeneration {
+		t.Fatalf(
+			"status observedGeneration = %d, expected %d",
+			runtimeResource.Status.ObservedGeneration,
+			expectedGeneration,
+		)
+	}
+}
+
+func assertProviderSecretProjection(
+	t *testing.T,
+	deployment *appsv1.Deployment,
+	secretName string,
+	secretKey string,
+) {
+	t.Helper()
+
+	if len(deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf(
+			"Deployment has %d containers, expected 1",
+			len(deployment.Spec.Template.Spec.Containers),
+		)
+	}
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	for _, environmentVariable := range container.Env {
+		if environmentVariable.Name != providerAPIKeyEnvironment {
+			continue
+		}
+
+		if environmentVariable.ValueFrom == nil {
+			t.Fatalf(
+				"%s must use valueFrom",
+				providerAPIKeyEnvironment,
+			)
+		}
+
+		secretReference := environmentVariable.ValueFrom.SecretKeyRef
+		if secretReference == nil {
+			t.Fatalf(
+				"%s must use secretKeyRef",
+				providerAPIKeyEnvironment,
+			)
+		}
+
+		if secretReference.Name != secretName {
+			t.Fatalf(
+				"%s Secret name = %q, expected %q",
+				providerAPIKeyEnvironment,
+				secretReference.Name,
+				secretName,
+			)
+		}
+
+		if secretReference.Key != secretKey {
+			t.Fatalf(
+				"%s Secret key = %q, expected %q",
+				providerAPIKeyEnvironment,
+				secretReference.Key,
+				secretKey,
+			)
+		}
+
+		return
+	}
+
+	t.Fatalf(
+		"Deployment does not project provider credential environment variable %q",
+		providerAPIKeyEnvironment,
+	)
+}
+
+func assertImagePullSecretProjection(
+	t *testing.T,
+	serviceAccount *corev1.ServiceAccount,
+	deployment *appsv1.Deployment,
+	secretName string,
+) {
+	t.Helper()
+
+	if !containsLocalObjectReference(
+		serviceAccount.ImagePullSecrets,
+		secretName,
+	) {
+		t.Fatalf(
+			"ServiceAccount imagePullSecrets does not contain %q",
+			secretName,
+		)
+	}
+
+	if !containsLocalObjectReference(
+		deployment.Spec.Template.Spec.ImagePullSecrets,
+		secretName,
+	) {
+		t.Fatalf(
+			"Deployment imagePullSecrets does not contain %q",
+			secretName,
+		)
+	}
+}
+
+func containsLocalObjectReference(
+	references []corev1.LocalObjectReference,
+	name string,
+) bool {
+	for _, reference := range references {
+		if reference.Name == name {
+			return true
+		}
+	}
+
+	return false
+}

--- a/internal/controller/integration/resource_lifecycle_test.go
+++ b/internal/controller/integration/resource_lifecycle_test.go
@@ -1,0 +1,708 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+const (
+	runtimeNameLabel      = "app.kubernetes.io/name"
+	runtimeInstanceLabel  = "app.kubernetes.io/instance"
+	runtimeManagedByLabel = "app.kubernetes.io/managed-by"
+
+	expectedRuntimeName      = "trussium"
+	expectedRuntimeManagedBy = "trussium-operator"
+
+	driftedLabelKey   = "drifted"
+	driftedLabelValue = "true"
+)
+
+func TestManagedResourceDriftCorrection(
+	t *testing.T,
+) {
+	namespace := createTestNamespace(t)
+	runtimeResource := createTestRuntime(
+		t,
+		namespace.Name,
+	)
+
+	key := client.ObjectKeyFromObject(runtimeResource)
+	initialGeneration := runtimeResource.Generation
+
+	service := waitForObject(
+		t,
+		key,
+		&corev1.Service{},
+	)
+
+	waitForObject(
+		t,
+		key,
+		&appsv1.Deployment{},
+	)
+
+	waitForObject(
+		t,
+		key,
+		&policyv1.PodDisruptionBudget{},
+	)
+
+	t.Run(
+		"corrects Service drift",
+		func(t *testing.T) {
+			driftService(
+				t,
+				service,
+			)
+
+			assertServiceRestored(
+				t,
+				key,
+				runtimeResource.Name,
+			)
+		},
+	)
+
+	t.Run(
+		"corrects Deployment drift",
+		func(t *testing.T) {
+			current := waitForObject(
+				t,
+				key,
+				&appsv1.Deployment{},
+			)
+
+			driftDeployment(
+				t,
+				current,
+			)
+
+			assertDeploymentRestored(
+				t,
+				key,
+			)
+		},
+	)
+
+	t.Run(
+		"corrects PodDisruptionBudget drift",
+		func(t *testing.T) {
+			current := waitForObject(
+				t,
+				key,
+				&policyv1.PodDisruptionBudget{},
+			)
+
+			driftPodDisruptionBudget(
+				t,
+				current,
+			)
+
+			assertPodDisruptionBudgetRestored(
+				t,
+				key,
+				runtimeResource.Name,
+			)
+		},
+	)
+
+	assertRuntimeGenerationPreserved(
+		t,
+		key,
+		initialGeneration,
+	)
+}
+
+func TestManagedResourceRecreation(
+	t *testing.T,
+) {
+	namespace := createTestNamespace(t)
+	runtimeResource := createTestRuntime(
+		t,
+		namespace.Name,
+	)
+
+	key := client.ObjectKeyFromObject(runtimeResource)
+	initialGeneration := runtimeResource.Generation
+
+	t.Run(
+		"recreates deleted Service",
+		func(t *testing.T) {
+			service := waitForObject(
+				t,
+				key,
+				&corev1.Service{},
+			)
+
+			oldUID := service.UID
+
+			deleteManagedObject(
+				t,
+				service,
+			)
+
+			recreated := waitForRecreatedObject(
+				t,
+				key,
+				&corev1.Service{},
+				oldUID,
+			)
+
+			assertControllerOwner(
+				t,
+				recreated,
+				runtimeResource,
+			)
+
+			assertServiceDesiredState(
+				t,
+				recreated,
+				runtimeResource.Name,
+			)
+		},
+	)
+
+	t.Run(
+		"recreates deleted Deployment",
+		func(t *testing.T) {
+			deployment := waitForObject(
+				t,
+				key,
+				&appsv1.Deployment{},
+			)
+
+			oldUID := deployment.UID
+
+			deleteManagedObject(
+				t,
+				deployment,
+			)
+
+			recreated := waitForRecreatedObject(
+				t,
+				key,
+				&appsv1.Deployment{},
+				oldUID,
+			)
+
+			assertControllerOwner(
+				t,
+				recreated,
+				runtimeResource,
+			)
+
+			assertDeploymentDesiredState(
+				t,
+				recreated,
+			)
+		},
+	)
+
+	t.Run(
+		"recreates deleted PodDisruptionBudget",
+		func(t *testing.T) {
+			podDisruptionBudget := waitForObject(
+				t,
+				key,
+				&policyv1.PodDisruptionBudget{},
+			)
+
+			oldUID := podDisruptionBudget.UID
+
+			deleteManagedObject(
+				t,
+				podDisruptionBudget,
+			)
+
+			recreated := waitForRecreatedObject(
+				t,
+				key,
+				&policyv1.PodDisruptionBudget{},
+				oldUID,
+			)
+
+			assertControllerOwner(
+				t,
+				recreated,
+				runtimeResource,
+			)
+
+			assertPodDisruptionBudgetDesiredState(
+				t,
+				recreated,
+				runtimeResource.Name,
+			)
+		},
+	)
+
+	assertRuntimeGenerationPreserved(
+		t,
+		key,
+		initialGeneration,
+	)
+}
+
+func driftService(
+	t *testing.T,
+	service *corev1.Service,
+) {
+	t.Helper()
+
+	current := service.DeepCopy()
+
+	current.Labels = map[string]string{
+		driftedLabelKey: driftedLabelValue,
+	}
+
+	current.Spec.Selector = map[string]string{
+		driftedLabelKey: driftedLabelValue,
+	}
+
+	if len(current.Spec.Ports) == 0 {
+		t.Fatal(
+			"Service has no ports to drift",
+		)
+	}
+
+	current.Spec.Ports[0].Port = 9999
+
+	if err := testClient.Update(
+		context.Background(),
+		current,
+	); err != nil {
+		t.Fatalf(
+			"introduce Service drift: %v",
+			err,
+		)
+	}
+}
+
+func driftDeployment(
+	t *testing.T,
+	deployment *appsv1.Deployment,
+) {
+	t.Helper()
+
+	current := deployment.DeepCopy()
+
+	replicas := int32(7)
+	current.Spec.Replicas = &replicas
+
+	current.Labels = map[string]string{
+		driftedLabelKey: driftedLabelValue,
+	}
+
+	if len(current.Spec.Template.Spec.Containers) == 0 {
+		t.Fatal(
+			"Deployment has no containers to drift",
+		)
+	}
+
+	current.Spec.Template.Spec.Containers[0].Image =
+		"invalid.example/drifted:latest"
+
+	if err := testClient.Update(
+		context.Background(),
+		current,
+	); err != nil {
+		t.Fatalf(
+			"introduce Deployment drift: %v",
+			err,
+		)
+	}
+}
+
+func driftPodDisruptionBudget(
+	t *testing.T,
+	podDisruptionBudget *policyv1.PodDisruptionBudget,
+) {
+	t.Helper()
+
+	current := podDisruptionBudget.DeepCopy()
+
+	maxUnavailable := intstr.FromInt32(0)
+	current.Spec.MaxUnavailable = &maxUnavailable
+
+	current.Labels = map[string]string{
+		driftedLabelKey: driftedLabelValue,
+	}
+
+	current.Spec.Selector.MatchLabels = map[string]string{
+		driftedLabelKey: driftedLabelValue,
+	}
+
+	if err := testClient.Update(
+		context.Background(),
+		current,
+	); err != nil {
+		t.Fatalf(
+			"introduce PodDisruptionBudget drift: %v",
+			err,
+		)
+	}
+}
+
+func assertServiceRestored(
+	t *testing.T,
+	key client.ObjectKey,
+	runtimeName string,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"Service desired state restored",
+		func() (bool, error) {
+			var service corev1.Service
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&service,
+			); err != nil {
+				return false, err
+			}
+
+			return serviceMatchesDesiredState(
+				&service,
+				runtimeName,
+			), nil
+		},
+	)
+}
+
+func assertDeploymentRestored(
+	t *testing.T,
+	key client.ObjectKey,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"Deployment desired state restored",
+		func() (bool, error) {
+			var deployment appsv1.Deployment
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&deployment,
+			); err != nil {
+				return false, err
+			}
+
+			return deploymentMatchesDesiredState(
+				&deployment,
+			), nil
+		},
+	)
+}
+
+func assertPodDisruptionBudgetRestored(
+	t *testing.T,
+	key client.ObjectKey,
+	runtimeName string,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"PodDisruptionBudget desired state restored",
+		func() (bool, error) {
+			var podDisruptionBudget policyv1.PodDisruptionBudget
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&podDisruptionBudget,
+			); err != nil {
+				return false, err
+			}
+
+			return podDisruptionBudgetMatchesDesiredState(
+				&podDisruptionBudget,
+				runtimeName,
+			), nil
+		},
+	)
+}
+
+func serviceMatchesDesiredState(
+	service *corev1.Service,
+	runtimeName string,
+) bool {
+	if service.Labels[runtimeNameLabel] != expectedRuntimeName {
+		return false
+	}
+
+	if service.Labels[runtimeInstanceLabel] != runtimeName {
+		return false
+	}
+
+	if service.Labels[runtimeManagedByLabel] !=
+		expectedRuntimeManagedBy {
+		return false
+	}
+
+	if service.Spec.Type != corev1.ServiceTypeClusterIP {
+		return false
+	}
+
+	if service.Spec.Selector[runtimeNameLabel] !=
+		expectedRuntimeName {
+		return false
+	}
+
+	if service.Spec.Selector[runtimeInstanceLabel] != runtimeName {
+		return false
+	}
+
+	if len(service.Spec.Ports) != 1 {
+		return false
+	}
+
+	if service.Spec.Ports[0].Port != 9000 {
+		return false
+	}
+
+	if service.Spec.Ports[0].TargetPort !=
+		intstr.FromString("http") {
+		return false
+	}
+
+	return true
+}
+
+func deploymentMatchesDesiredState(
+	deployment *appsv1.Deployment,
+) bool {
+	if deployment.Labels[runtimeNameLabel] !=
+		expectedRuntimeName {
+		return false
+	}
+
+	if deployment.Labels[runtimeManagedByLabel] !=
+		expectedRuntimeManagedBy {
+		return false
+	}
+
+	if deployment.Spec.Replicas == nil ||
+		*deployment.Spec.Replicas != 1 {
+		return false
+	}
+
+	if len(deployment.Spec.Template.Spec.Containers) != 1 {
+		return false
+	}
+
+	container := deployment.Spec.Template.Spec.Containers[0]
+
+	expectedImage :=
+		testRuntimeImageRepository + ":" + testRuntimeImageTag
+
+	if container.Name != "trussium" {
+		return false
+	}
+
+	if container.Image != expectedImage {
+		return false
+	}
+
+	return true
+}
+
+func podDisruptionBudgetMatchesDesiredState(
+	podDisruptionBudget *policyv1.PodDisruptionBudget,
+	runtimeName string,
+) bool {
+	if podDisruptionBudget.Labels[runtimeNameLabel] !=
+		expectedRuntimeName {
+		return false
+	}
+
+	if podDisruptionBudget.Labels[runtimeManagedByLabel] !=
+		expectedRuntimeManagedBy {
+		return false
+	}
+
+	if podDisruptionBudget.Spec.MaxUnavailable == nil {
+		return false
+	}
+
+	expectedMaxUnavailable := intstr.FromInt32(1)
+	if *podDisruptionBudget.Spec.MaxUnavailable !=
+		expectedMaxUnavailable {
+		return false
+	}
+
+	if podDisruptionBudget.Spec.Selector == nil {
+		return false
+	}
+
+	if podDisruptionBudget.Spec.Selector.MatchLabels[runtimeNameLabel] !=
+		expectedRuntimeName {
+		return false
+	}
+
+	if podDisruptionBudget.Spec.Selector.MatchLabels[runtimeInstanceLabel] !=
+		runtimeName {
+		return false
+	}
+
+	return true
+}
+
+func assertServiceDesiredState(
+	t *testing.T,
+	service *corev1.Service,
+	runtimeName string,
+) {
+	t.Helper()
+
+	if !serviceMatchesDesiredState(
+		service,
+		runtimeName,
+	) {
+		t.Fatalf(
+			"recreated Service %s/%s does not match desired state",
+			service.Namespace,
+			service.Name,
+		)
+	}
+}
+
+func assertDeploymentDesiredState(
+	t *testing.T,
+	deployment *appsv1.Deployment,
+) {
+	t.Helper()
+
+	if !deploymentMatchesDesiredState(
+		deployment,
+	) {
+		t.Fatalf(
+			"recreated Deployment %s/%s does not match desired state",
+			deployment.Namespace,
+			deployment.Name,
+		)
+	}
+}
+
+func assertPodDisruptionBudgetDesiredState(
+	t *testing.T,
+	podDisruptionBudget *policyv1.PodDisruptionBudget,
+	runtimeName string,
+) {
+	t.Helper()
+
+	if !podDisruptionBudgetMatchesDesiredState(
+		podDisruptionBudget,
+		runtimeName,
+	) {
+		t.Fatalf(
+			"recreated PodDisruptionBudget %s/%s does not match desired state",
+			podDisruptionBudget.Namespace,
+			podDisruptionBudget.Name,
+		)
+	}
+}
+
+func deleteManagedObject(
+	t *testing.T,
+	object client.Object,
+) {
+	t.Helper()
+
+	if err := testClient.Delete(
+		context.Background(),
+		object,
+	); err != nil {
+		t.Fatalf(
+			"delete managed %T %s/%s: %v",
+			object,
+			object.GetNamespace(),
+			object.GetName(),
+			err,
+		)
+	}
+}
+
+func waitForRecreatedObject[T client.Object](
+	t *testing.T,
+	key client.ObjectKey,
+	object T,
+	oldUID types.UID,
+) T {
+	t.Helper()
+
+	eventually(
+		t,
+		"managed resource recreated",
+		func() (bool, error) {
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				object,
+			); err != nil {
+				return false, client.IgnoreNotFound(err)
+			}
+
+			return object.GetUID() != "" &&
+				object.GetUID() != oldUID, nil
+		},
+	)
+
+	return object
+}
+
+func assertRuntimeGenerationPreserved(
+	t *testing.T,
+	key client.ObjectKey,
+	expectedGeneration int64,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"TrussiumRuntime generation remains unchanged",
+		func() (bool, error) {
+			var runtimeResource runtimev1alpha1.TrussiumRuntime
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&runtimeResource,
+			); err != nil {
+				return false, err
+			}
+
+			return runtimeResource.Generation ==
+				expectedGeneration, nil
+		},
+	)
+}

--- a/internal/controller/integration/rollout_fixtures_test.go
+++ b/internal/controller/integration/rollout_fixtures_test.go
@@ -1,0 +1,475 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+const (
+	testRuntimeImageTagV2 = "0.24.0"
+
+	runtimeConfigChecksumAnnotation = "runtime.trussium.io/config-checksum"
+
+	upgradingConditionType = "Upgrading"
+
+	noUpgradeReason         = "NoUpgrade"
+	upgradeInProgressReason = "UpgradeInProgress"
+	upgradeCompleteReason   = "UpgradeComplete"
+	upgradeFailedReason     = "UpgradeFailed"
+	scaledToZeroReason      = "ScaledToZero"
+
+	progressDeadlineExceededReason = "ProgressDeadlineExceeded"
+
+	providerBaseURLEnvironment = "TRUSSIUM_PROVIDER__BASE_URL"
+)
+
+type runtimeRolloutFixture struct {
+	Runtime    *runtimev1alpha1.TrussiumRuntime
+	Key        client.ObjectKey
+	Deployment *appsv1.Deployment
+}
+
+func establishSuccessfulRuntime(
+	t *testing.T,
+) runtimeRolloutFixture {
+	t.Helper()
+
+	namespace := createTestNamespace(t)
+
+	runtimeResource := createTestRuntime(
+		t,
+		namespace.Name,
+	)
+
+	key := client.ObjectKeyFromObject(runtimeResource)
+
+	waitForObject(
+		t,
+		key,
+		&appsv1.Deployment{},
+	)
+
+	deployment := markDeploymentRolloutComplete(
+		t,
+		key,
+	)
+
+	initialImage :=
+		testRuntimeImageRepository + ":" + testRuntimeImageTag
+
+	current := waitForRuntimeStatus(
+		t,
+		key,
+		func(
+			resource *runtimev1alpha1.TrussiumRuntime,
+		) bool {
+			condition := runtimeCondition(
+				resource,
+				upgradingConditionType,
+			)
+
+			return resource.Status.LastSuccessfulImage ==
+				initialImage &&
+				condition != nil &&
+				condition.Status == metav1.ConditionFalse &&
+				condition.Reason == noUpgradeReason
+		},
+	)
+
+	return runtimeRolloutFixture{
+		Runtime:    current,
+		Key:        key,
+		Deployment: deployment,
+	}
+}
+
+func markDeploymentRolloutComplete(
+	t *testing.T,
+	key client.ObjectKey,
+) *appsv1.Deployment {
+	t.Helper()
+
+	var completedDeployment appsv1.Deployment
+
+	eventually(
+		t,
+		"Deployment rollout status becomes complete",
+		func() (bool, error) {
+			var deployment appsv1.Deployment
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&deployment,
+			); err != nil {
+				return false, err
+			}
+
+			desiredReplicas := int32(1)
+			if deployment.Spec.Replicas != nil {
+				desiredReplicas = *deployment.Spec.Replicas
+			}
+
+			deployment.Status.ObservedGeneration =
+				deployment.Generation
+			deployment.Status.Replicas =
+				desiredReplicas
+			deployment.Status.UpdatedReplicas =
+				desiredReplicas
+			deployment.Status.ReadyReplicas =
+				desiredReplicas
+			deployment.Status.AvailableReplicas =
+				desiredReplicas
+			deployment.Status.UnavailableReplicas = 0
+
+			if err := testClient.Status().Update(
+				context.Background(),
+				&deployment,
+			); err != nil {
+				if apierrors.IsConflict(err) {
+					return false, nil
+				}
+
+				return false, err
+			}
+
+			completedDeployment = *deployment.DeepCopy()
+
+			return true, nil
+		},
+	)
+
+	return completedDeployment.DeepCopy()
+}
+
+func markDeploymentRolloutFailed(
+	t *testing.T,
+	key client.ObjectKey,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"Deployment rollout status becomes failed",
+		func() (bool, error) {
+			var deployment appsv1.Deployment
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&deployment,
+			); err != nil {
+				return false, err
+			}
+
+			deployment.Status.ObservedGeneration =
+				deployment.Generation
+			deployment.Status.Conditions =
+				[]appsv1.DeploymentCondition{
+					{
+						Type:               appsv1.DeploymentProgressing,
+						Status:             corev1.ConditionFalse,
+						Reason:             progressDeadlineExceededReason,
+						Message:            "integration test simulated progress deadline failure",
+						LastUpdateTime:     metav1.Now(),
+						LastTransitionTime: metav1.Now(),
+					},
+				}
+
+			if err := testClient.Status().Update(
+				context.Background(),
+				&deployment,
+			); err != nil {
+				if apierrors.IsConflict(err) {
+					return false, nil
+				}
+
+				return false, err
+			}
+
+			return true, nil
+		},
+	)
+}
+
+func updateRuntimeProviderBaseURL(
+	t *testing.T,
+	key client.ObjectKey,
+	baseURL string,
+) *runtimev1alpha1.TrussiumRuntime {
+	t.Helper()
+
+	var updatedRuntime runtimev1alpha1.TrussiumRuntime
+
+	err := retry.RetryOnConflict(
+		retry.DefaultBackoff,
+		func() error {
+			var runtimeResource runtimev1alpha1.TrussiumRuntime
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&runtimeResource,
+			); err != nil {
+				return err
+			}
+
+			runtimeResource.Spec.Provider.BaseURL = &baseURL
+
+			if err := testClient.Update(
+				context.Background(),
+				&runtimeResource,
+			); err != nil {
+				return err
+			}
+
+			updatedRuntime = *runtimeResource.DeepCopy()
+
+			return nil
+		},
+	)
+	if err != nil {
+		t.Fatalf(
+			"update TrussiumRuntime provider base URL: %v",
+			err,
+		)
+	}
+
+	return updatedRuntime.DeepCopy()
+}
+
+func updateRuntimeImageTag(
+	t *testing.T,
+	key client.ObjectKey,
+) {
+	t.Helper()
+
+	err := retry.RetryOnConflict(
+		retry.DefaultBackoff,
+		func() error {
+			var runtimeResource runtimev1alpha1.TrussiumRuntime
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&runtimeResource,
+			); err != nil {
+				return err
+			}
+
+			tag := testRuntimeImageTagV2
+
+			runtimeResource.Spec.Image.Tag = &tag
+			runtimeResource.Spec.Image.Digest = nil
+
+			return testClient.Update(
+				context.Background(),
+				&runtimeResource,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatalf(
+			"update TrussiumRuntime image tag: %v",
+			err,
+		)
+	}
+}
+
+func deploymentConfigChecksum(
+	t *testing.T,
+	deployment *appsv1.Deployment,
+) string {
+	t.Helper()
+
+	checksum := deployment.Spec.Template.Annotations[runtimeConfigChecksumAnnotation]
+
+	if checksum == "" {
+		t.Fatalf(
+			"Deployment %s/%s is missing %q annotation",
+			deployment.Namespace,
+			deployment.Name,
+			runtimeConfigChecksumAnnotation,
+		)
+	}
+
+	return checksum
+}
+
+func waitForDeploymentChecksumChange(
+	t *testing.T,
+	key client.ObjectKey,
+	previousChecksum string,
+	previousGeneration int64,
+) *appsv1.Deployment {
+	t.Helper()
+
+	var current appsv1.Deployment
+
+	eventually(
+		t,
+		"Deployment configuration checksum changes",
+		func() (bool, error) {
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&current,
+			); err != nil {
+				return false, err
+			}
+
+			checksum :=
+				current.Spec.Template.Annotations[runtimeConfigChecksumAnnotation]
+
+			return checksum != "" &&
+					checksum != previousChecksum &&
+					current.Generation > previousGeneration,
+				nil
+		},
+	)
+
+	return current.DeepCopy()
+}
+
+func waitForDeploymentImage(
+	t *testing.T,
+	key client.ObjectKey,
+	previousGeneration int64,
+) *appsv1.Deployment {
+	t.Helper()
+
+	var current appsv1.Deployment
+
+	expectedImage :=
+		testRuntimeImageRepository + ":" +
+			testRuntimeImageTagV2
+
+	eventually(
+		t,
+		"Deployment runtime image changes",
+		func() (bool, error) {
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&current,
+			); err != nil {
+				return false, err
+			}
+
+			if len(
+				current.Spec.Template.Spec.Containers,
+			) != 1 {
+				return false, nil
+			}
+
+			return current.Spec.Template.Spec.
+					Containers[0].Image == expectedImage &&
+					current.Generation > previousGeneration,
+				nil
+		},
+	)
+
+	return current.DeepCopy()
+}
+
+func waitForUpgradeConditionState(
+	t *testing.T,
+	key client.ObjectKey,
+	status metav1.ConditionStatus,
+	reason string,
+) *runtimev1alpha1.TrussiumRuntime {
+	t.Helper()
+
+	return waitForRuntimeStatus(
+		t,
+		key,
+		func(
+			runtimeResource *runtimev1alpha1.TrussiumRuntime,
+		) bool {
+			condition := runtimeCondition(
+				runtimeResource,
+				upgradingConditionType,
+			)
+
+			return condition != nil &&
+				condition.Status == status &&
+				condition.Reason == reason
+		},
+	)
+}
+
+func waitForConfigMapValue(
+	t *testing.T,
+	key client.ObjectKey,
+	name string,
+	expectedValue string,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"ConfigMap configuration value is updated",
+		func() (bool, error) {
+			var configMap corev1.ConfigMap
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&configMap,
+			); err != nil {
+				return false, err
+			}
+
+			return configMap.Data[name] ==
+				expectedValue, nil
+		},
+	)
+}
+
+func runtimeContainerImage(
+	t *testing.T,
+	deployment *appsv1.Deployment,
+) string {
+	t.Helper()
+
+	if len(
+		deployment.Spec.Template.Spec.Containers,
+	) != 1 {
+		t.Fatalf(
+			"Deployment %s/%s has %d containers, expected 1",
+			deployment.Namespace,
+			deployment.Name,
+			len(
+				deployment.Spec.Template.Spec.Containers,
+			),
+		)
+	}
+
+	return deployment.Spec.Template.Spec.
+		Containers[0].Image
+}

--- a/internal/controller/integration/rollout_test.go
+++ b/internal/controller/integration/rollout_test.go
@@ -1,0 +1,382 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+func TestConfigurationRolloutAndSuccessfulImageUpgrade(
+	t *testing.T,
+) {
+	fixture := establishSuccessfulRuntime(t)
+
+	initialImage :=
+		testRuntimeImageRepository + ":" +
+			testRuntimeImageTag
+
+	initialChecksum := deploymentConfigChecksum(
+		t,
+		fixture.Deployment,
+	)
+
+	initialDeploymentGeneration :=
+		fixture.Deployment.Generation
+
+	t.Run(
+		"configuration change rolls the Deployment without an image upgrade",
+		func(t *testing.T) {
+			baseURL :=
+				"http://ollama.integration.invalid:11434"
+
+			updatedRuntime :=
+				updateRuntimeProviderBaseURL(
+					t,
+					fixture.Key,
+					baseURL,
+				)
+
+			if updatedRuntime.Generation <=
+				fixture.Runtime.Generation {
+				t.Fatalf(
+					"TrussiumRuntime generation = %d after configuration update, expected greater than %d",
+					updatedRuntime.Generation,
+					fixture.Runtime.Generation,
+				)
+			}
+
+			waitForConfigMapValue(
+				t,
+				fixture.Key,
+				providerBaseURLEnvironment,
+				baseURL,
+			)
+
+			rolledDeployment :=
+				waitForDeploymentChecksumChange(
+					t,
+					fixture.Key,
+					initialChecksum,
+					initialDeploymentGeneration,
+				)
+
+			if runtimeContainerImage(
+				t,
+				rolledDeployment,
+			) != initialImage {
+				t.Fatalf(
+					"configuration rollout changed runtime image to %q, expected %q",
+					runtimeContainerImage(
+						t,
+						rolledDeployment,
+					),
+					initialImage,
+				)
+			}
+
+			current :=
+				waitForUpgradeConditionState(
+					t,
+					fixture.Key,
+					metav1.ConditionFalse,
+					noUpgradeReason,
+				)
+
+			if current.Status.LastSuccessfulImage !=
+				initialImage {
+				t.Fatalf(
+					"lastSuccessfulImage = %q after configuration rollout, expected %q",
+					current.Status.LastSuccessfulImage,
+					initialImage,
+				)
+			}
+
+			completedDeployment :=
+				markDeploymentRolloutComplete(
+					t,
+					fixture.Key,
+				)
+
+			waitForRuntimeStatus(
+				t,
+				fixture.Key,
+				func(
+					runtimeResource *runtimev1alpha1.TrussiumRuntime,
+				) bool {
+					return runtimeResource.Status.
+						LastSuccessfulImage ==
+						initialImage &&
+						runtimeResource.Status.
+							ReadyReplicas == 1 &&
+						runtimeResource.Status.
+							AvailableReplicas == 1
+				},
+			)
+
+			fixture.Deployment =
+				completedDeployment
+			fixture.Runtime =
+				updatedRuntime
+		},
+	)
+
+	t.Run(
+		"image change completes an upgrade",
+		func(t *testing.T) {
+			previousGeneration :=
+				fixture.Deployment.Generation
+
+			updateRuntimeImageTag(
+				t,
+				fixture.Key,
+			)
+
+			expectedImage :=
+				testRuntimeImageRepository + ":" +
+					testRuntimeImageTagV2
+
+			upgradingDeployment :=
+				waitForDeploymentImage(
+					t,
+					fixture.Key,
+					previousGeneration,
+				)
+
+			inProgress :=
+				waitForUpgradeConditionState(
+					t,
+					fixture.Key,
+					metav1.ConditionTrue,
+					upgradeInProgressReason,
+				)
+
+			if inProgress.Status.LastSuccessfulImage !=
+				initialImage {
+				t.Fatalf(
+					"lastSuccessfulImage = %q during upgrade, expected %q",
+					inProgress.Status.LastSuccessfulImage,
+					initialImage,
+				)
+			}
+
+			if inProgress.Status.DesiredImage !=
+				expectedImage {
+				t.Fatalf(
+					"desiredImage = %q during upgrade, expected %q",
+					inProgress.Status.DesiredImage,
+					expectedImage,
+				)
+			}
+
+			if inProgress.Status.CurrentImage !=
+				expectedImage {
+				t.Fatalf(
+					"currentImage = %q during upgrade, expected %q",
+					inProgress.Status.CurrentImage,
+					expectedImage,
+				)
+			}
+
+			markDeploymentRolloutComplete(
+				t,
+				fixture.Key,
+			)
+
+			completed :=
+				waitForUpgradeConditionState(
+					t,
+					fixture.Key,
+					metav1.ConditionFalse,
+					upgradeCompleteReason,
+				)
+
+			if completed.Status.LastSuccessfulImage !=
+				expectedImage {
+				t.Fatalf(
+					"lastSuccessfulImage = %q after successful upgrade, expected %q",
+					completed.Status.LastSuccessfulImage,
+					expectedImage,
+				)
+			}
+
+			if completed.Status.DesiredImage !=
+				expectedImage {
+				t.Fatalf(
+					"desiredImage = %q after successful upgrade, expected %q",
+					completed.Status.DesiredImage,
+					expectedImage,
+				)
+			}
+
+			if completed.Status.CurrentImage !=
+				expectedImage {
+				t.Fatalf(
+					"currentImage = %q after successful upgrade, expected %q",
+					completed.Status.CurrentImage,
+					expectedImage,
+				)
+			}
+
+			if runtimeContainerImage(
+				t,
+				upgradingDeployment,
+			) != expectedImage {
+				t.Fatalf(
+					"Deployment image = %q, expected %q",
+					runtimeContainerImage(
+						t,
+						upgradingDeployment,
+					),
+					expectedImage,
+				)
+			}
+		},
+	)
+}
+
+func TestFailedImageUpgradeDoesNotRollback(
+	t *testing.T,
+) {
+	fixture := establishSuccessfulRuntime(t)
+
+	initialImage :=
+		testRuntimeImageRepository + ":" +
+			testRuntimeImageTag
+
+	expectedImage :=
+		testRuntimeImageRepository + ":" +
+			testRuntimeImageTagV2
+
+	previousGeneration :=
+		fixture.Deployment.Generation
+
+	updateRuntimeImageTag(
+		t,
+		fixture.Key,
+	)
+
+	waitForDeploymentImage(
+		t,
+		fixture.Key,
+		previousGeneration,
+	)
+
+	waitForUpgradeConditionState(
+		t,
+		fixture.Key,
+		metav1.ConditionTrue,
+		upgradeInProgressReason,
+	)
+
+	markDeploymentRolloutFailed(
+		t,
+		fixture.Key,
+	)
+
+	failed :=
+		waitForUpgradeConditionState(
+			t,
+			fixture.Key,
+			metav1.ConditionFalse,
+			upgradeFailedReason,
+		)
+
+	if failed.Status.LastSuccessfulImage !=
+		initialImage {
+		t.Fatalf(
+			"lastSuccessfulImage = %q after failed upgrade, expected %q",
+			failed.Status.LastSuccessfulImage,
+			initialImage,
+		)
+	}
+
+	if failed.Status.DesiredImage != expectedImage {
+		t.Fatalf(
+			"desiredImage = %q after failed upgrade, expected %q",
+			failed.Status.DesiredImage,
+			expectedImage,
+		)
+	}
+
+	if failed.Status.CurrentImage != expectedImage {
+		t.Fatalf(
+			"currentImage = %q after failed upgrade, expected %q",
+			failed.Status.CurrentImage,
+			expectedImage,
+		)
+	}
+
+	degraded := runtimeCondition(
+		failed,
+		"Degraded",
+	)
+
+	if degraded == nil {
+		t.Fatal(
+			"Degraded condition was not persisted after failed upgrade",
+		)
+	}
+
+	if degraded.Status != metav1.ConditionTrue {
+		t.Fatalf(
+			"Degraded status = %q after failed upgrade, expected True",
+			degraded.Status,
+		)
+	}
+
+	if degraded.Reason !=
+		progressDeadlineExceededReason {
+		t.Fatalf(
+			"Degraded reason = %q after failed upgrade, expected %q",
+			degraded.Reason,
+			progressDeadlineExceededReason,
+		)
+	}
+
+	var deployment appsv1.Deployment
+
+	if err := testClient.Get(
+		context.Background(),
+		fixture.Key,
+		&deployment,
+	); err != nil {
+		t.Fatalf(
+			"get Deployment after failed upgrade: %v",
+			err,
+		)
+	}
+
+	if runtimeContainerImage(
+		t,
+		&deployment,
+	) != expectedImage {
+		t.Fatalf(
+			"Deployment image was rolled back to %q, expected failed desired image %q to remain",
+			runtimeContainerImage(
+				t,
+				&deployment,
+			),
+			expectedImage,
+		)
+	}
+}

--- a/internal/controller/integration/scale_zero_test.go
+++ b/internal/controller/integration/scale_zero_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"testing"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+)
+
+func TestRuntimeScalesToZero(
+	t *testing.T,
+) {
+	fixture := establishSuccessfulRuntime(t)
+
+	initialImage :=
+		testRuntimeImageRepository + ":" +
+			testRuntimeImageTag
+
+	previousRuntimeGeneration :=
+		fixture.Runtime.Generation
+
+	updateRuntimeReplicas(
+		t,
+		fixture.Key,
+		0,
+	)
+
+	deployment := waitForDeploymentReplicas(
+		t,
+		fixture.Key,
+		0,
+	)
+
+	if deployment.Spec.Replicas == nil {
+		t.Fatal(
+			"Deployment replicas must be set after scale to zero",
+		)
+	}
+
+	if *deployment.Spec.Replicas != 0 {
+		t.Fatalf(
+			"Deployment replicas = %d, expected 0",
+			*deployment.Spec.Replicas,
+		)
+	}
+
+	markDeploymentScaledToZero(
+		t,
+		fixture.Key,
+	)
+
+	scaledRuntime := waitForRuntimeStatus(
+		t,
+		fixture.Key,
+		func(
+			runtimeResource *runtimev1alpha1.TrussiumRuntime,
+		) bool {
+			return runtimeResource.Generation >
+				previousRuntimeGeneration &&
+				runtimeResource.Status.ObservedGeneration ==
+					runtimeResource.Generation &&
+				runtimeResource.Status.ReadyReplicas == 0 &&
+				runtimeResource.Status.AvailableReplicas == 0
+		},
+	)
+
+	if scaledRuntime.Status.DesiredImage !=
+		initialImage {
+		t.Fatalf(
+			"desiredImage = %q after scale to zero, expected %q",
+			scaledRuntime.Status.DesiredImage,
+			initialImage,
+		)
+	}
+
+	if scaledRuntime.Status.CurrentImage !=
+		initialImage {
+		t.Fatalf(
+			"currentImage = %q after scale to zero, expected %q",
+			scaledRuntime.Status.CurrentImage,
+			initialImage,
+		)
+	}
+
+	if scaledRuntime.Status.LastSuccessfulImage !=
+		initialImage {
+		t.Fatalf(
+			"lastSuccessfulImage = %q after scale to zero, expected %q",
+			scaledRuntime.Status.LastSuccessfulImage,
+			initialImage,
+		)
+	}
+
+	progressing := runtimeCondition(
+		scaledRuntime,
+		"Progressing",
+	)
+	if progressing == nil {
+		t.Fatal(
+			"Progressing condition was not persisted after scale to zero",
+		)
+	}
+
+	if progressing.Status != metav1.ConditionFalse {
+		t.Fatalf(
+			"Progressing status = %q after scale to zero, expected False",
+			progressing.Status,
+		)
+	}
+
+	if progressing.Reason != scaledToZeroReason {
+		t.Fatalf(
+			"Progressing reason = %q after scale to zero, expected %q",
+			progressing.Reason,
+			scaledToZeroReason,
+		)
+	}
+
+	ready := runtimeCondition(
+		scaledRuntime,
+		"Ready",
+	)
+	if ready == nil {
+		t.Fatal(
+			"Ready condition was not persisted after scale to zero",
+		)
+	}
+
+	if ready.Status != metav1.ConditionTrue {
+		t.Fatalf(
+			"Ready status = %q after scale to zero, expected True",
+			ready.Status,
+		)
+	}
+
+	if ready.Reason != scaledToZeroReason {
+		t.Fatalf(
+			"Ready reason = %q after scale to zero, expected %q",
+			ready.Reason,
+			scaledToZeroReason,
+		)
+	}
+
+	upgrading := runtimeCondition(
+		scaledRuntime,
+		upgradingConditionType,
+	)
+	if upgrading == nil {
+		t.Fatal(
+			"Upgrading condition was not persisted after scale to zero",
+		)
+	}
+
+	if upgrading.Status != metav1.ConditionFalse {
+		t.Fatalf(
+			"Upgrading status = %q after scale to zero, expected False",
+			upgrading.Status,
+		)
+	}
+
+	if upgrading.Reason != noUpgradeReason {
+		t.Fatalf(
+			"Upgrading reason = %q after scale to zero, expected %q",
+			upgrading.Reason,
+			noUpgradeReason,
+		)
+	}
+}
+
+func updateRuntimeReplicas(
+	t *testing.T,
+	key client.ObjectKey,
+	replicas int32,
+) {
+	t.Helper()
+
+	err := retry.RetryOnConflict(
+		retry.DefaultBackoff,
+		func() error {
+			var runtimeResource runtimev1alpha1.TrussiumRuntime
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&runtimeResource,
+			); err != nil {
+				return err
+			}
+
+			runtimeResource.Spec.Replicas = &replicas
+
+			return testClient.Update(
+				context.Background(),
+				&runtimeResource,
+			)
+		},
+	)
+	if err != nil {
+		t.Fatalf(
+			"update TrussiumRuntime replicas to %d: %v",
+			replicas,
+			err,
+		)
+	}
+}
+
+func waitForDeploymentReplicas(
+	t *testing.T,
+	key client.ObjectKey,
+	expectedReplicas int32,
+) *appsv1.Deployment {
+	t.Helper()
+
+	var deployment appsv1.Deployment
+
+	eventually(
+		t,
+		"Deployment replica count is reconciled",
+		func() (bool, error) {
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&deployment,
+			); err != nil {
+				return false, err
+			}
+
+			return deployment.Spec.Replicas != nil &&
+					*deployment.Spec.Replicas ==
+						expectedReplicas,
+				nil
+		},
+	)
+
+	return deployment.DeepCopy()
+}
+
+func markDeploymentScaledToZero(
+	t *testing.T,
+	key client.ObjectKey,
+) {
+	t.Helper()
+
+	eventually(
+		t,
+		"Deployment status reaches scaled-to-zero state",
+		func() (bool, error) {
+			var deployment appsv1.Deployment
+
+			if err := testClient.Get(
+				context.Background(),
+				key,
+				&deployment,
+			); err != nil {
+				return false, err
+			}
+
+			if deployment.Spec.Replicas == nil ||
+				*deployment.Spec.Replicas != 0 {
+				return false, nil
+			}
+
+			deployment.Status.ObservedGeneration =
+				deployment.Generation
+			deployment.Status.Replicas = 0
+			deployment.Status.UpdatedReplicas = 0
+			deployment.Status.ReadyReplicas = 0
+			deployment.Status.AvailableReplicas = 0
+			deployment.Status.UnavailableReplicas = 0
+
+			if err := testClient.Status().Update(
+				context.Background(),
+				&deployment,
+			); err != nil {
+				if apierrors.IsConflict(err) {
+					return false, nil
+				}
+
+				return false, err
+			}
+
+			return true, nil
+		},
+	)
+}

--- a/internal/controller/integration/suite_test.go
+++ b/internal/controller/integration/suite_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package integration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"testing"
+	"time"
+
+	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+
+	runtimev1alpha1 "github.com/trussiumhq/trussium-operator/api/v1alpha1"
+	"github.com/trussiumhq/trussium-operator/internal/controller"
+)
+
+const (
+	integrationTimeout      = 15 * time.Second
+	integrationPollInterval = 100 * time.Millisecond
+)
+
+var (
+	testEnvironment *envtest.Environment
+	testClient      client.Client
+	testScheme      *runtime.Scheme
+)
+
+func TestMain(m *testing.M) {
+	projectRoot, err := integrationProjectRoot()
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"resolve project root: %v\n",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	testScheme = runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(testScheme))
+	utilruntime.Must(eventsv1.AddToScheme(testScheme))
+	utilruntime.Must(runtimev1alpha1.AddToScheme(testScheme))
+
+	testEnvironment = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join(
+				projectRoot,
+				"config",
+				"crd",
+				"bases",
+			),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	restConfig, err := testEnvironment.Start()
+	if err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"start envtest environment: %v\n",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	manager, err := ctrl.NewManager(
+		restConfig,
+		ctrl.Options{
+			Scheme: testScheme,
+			Metrics: metricsserver.Options{
+				BindAddress: "0",
+			},
+			HealthProbeBindAddress: "0",
+			LeaderElection:         false,
+		},
+	)
+	if err != nil {
+		_ = testEnvironment.Stop()
+
+		fmt.Fprintf(
+			os.Stderr,
+			"create controller manager: %v\n",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	reconciler := &controller.TrussiumRuntimeReconciler{
+		Client: manager.GetClient(),
+		Scheme: manager.GetScheme(),
+		Recorder: manager.GetEventRecorder(
+			"trussiumruntime-integration",
+		),
+	}
+
+	if err := reconciler.SetupWithManager(manager); err != nil {
+		_ = testEnvironment.Stop()
+
+		fmt.Fprintf(
+			os.Stderr,
+			"register TrussiumRuntime controller: %v\n",
+			err,
+		)
+		os.Exit(1)
+	}
+
+	managerContext, cancelManager := context.WithCancel(
+		context.Background(),
+	)
+
+	managerDone := make(chan error, 1)
+
+	go func() {
+		managerDone <- manager.Start(managerContext)
+	}()
+
+	cacheContext, cancelCacheWait := context.WithTimeout(
+		context.Background(),
+		integrationTimeout,
+	)
+
+	cacheStarted :=
+		manager.GetCache().WaitForCacheSync(cacheContext)
+
+	cancelCacheWait()
+
+	if !cacheStarted {
+		cancelManager()
+		_ = waitForManagerStop(managerDone)
+		_ = testEnvironment.Stop()
+
+		fmt.Fprintln(
+			os.Stderr,
+			"controller manager cache did not synchronize before timeout",
+		)
+
+		os.Exit(1)
+	}
+
+	testClient, err = client.New(
+		restConfig,
+		client.Options{
+			Scheme: testScheme,
+		},
+	)
+	if err != nil {
+		cancelManager()
+		_ = waitForManagerStop(managerDone)
+		_ = testEnvironment.Stop()
+
+		fmt.Fprintf(
+			os.Stderr,
+			"create integration test client: %v\n",
+			err,
+		)
+
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+
+	cancelManager()
+
+	if err := waitForManagerStop(managerDone); err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"stop controller manager: %v\n",
+			err,
+		)
+
+		if exitCode == 0 {
+			exitCode = 1
+		}
+	}
+
+	if err := testEnvironment.Stop(); err != nil {
+		fmt.Fprintf(
+			os.Stderr,
+			"stop envtest environment: %v\n",
+			err,
+		)
+
+		if exitCode == 0 {
+			exitCode = 1
+		}
+	}
+
+	os.Exit(exitCode)
+}
+
+func integrationProjectRoot() (string, error) {
+	_, currentFile, _, ok := goruntime.Caller(0)
+	if !ok {
+		return "", errors.New(
+			"determine suite source file",
+		)
+	}
+
+	return filepath.Clean(
+		filepath.Join(
+			filepath.Dir(currentFile),
+			"..",
+			"..",
+			"..",
+		),
+	), nil
+}
+
+func waitForManagerStop(
+	managerDone <-chan error,
+) error {
+	select {
+	case err := <-managerDone:
+		if err == nil ||
+			errors.Is(err, context.Canceled) {
+			return nil
+		}
+
+		return err
+
+	case <-time.After(integrationTimeout):
+		return errors.New(
+			"controller manager did not stop before timeout",
+		)
+	}
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -9,7 +9,6 @@ you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,313 +24,1900 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	"github.com/trussiumhq/trussium-operator/test/utils"
 )
 
-// namespace where the project is deployed in
 const namespace = "trussium-operator-system"
 
-// serviceAccountName created for the project
 const serviceAccountName = "trussium-operator-controller-manager"
 
-// metricsServiceName is the name of the metrics service of the project
 const metricsServiceName = "trussium-operator-controller-manager-metrics-service"
 
-// metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
 const metricsRoleBindingName = "trussium-operator-metrics-binding"
+
+const (
+	runtimeResourceName = "smoke-runtime"
+
+	runtimeImageRepository = "ghcr.io/trussiumhq/trussium"
+
+	initialRuntimeImageTag  = "0.23.0"
+	upgradedRuntimeImageTag = "0.24.0"
+
+	runtimeImage = runtimeImageRepository + ":" + initialRuntimeImageTag
+
+	upgradedRuntimeImage = runtimeImageRepository + ":" + upgradedRuntimeImageTag
+
+	runtimeConfigChecksumAnnotation = "runtime.trussium.io/config-checksum"
+
+	runtimeProviderBaseURLEnvironment = "TRUSSIUM_PROVIDER__BASE_URL"
+
+	initialRuntimeModel = "llama3.2"
+
+	initialRuntimeProviderBaseURL = "http://ollama.default.svc.cluster.local:11434"
+	updatedRuntimeProviderBaseURL = "http://ollama-updated.default.svc.cluster.local:11434"
+
+	runtimeUpgradeStartedEvent = "RuntimeUpgradeStarted"
+
+	runtimeUpgradeCompletedEvent = "RuntimeUpgradeCompleted"
+
+	upgradeCompleteReason = "UpgradeComplete"
+)
 
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
 
-	// Before running the tests, set up the environment by creating the namespace,
-	// enforce the restricted security policy to the namespace, installing CRDs,
-	// and deploying the controller.
 	BeforeAll(func() {
 		By("creating manager namespace")
-		cmd := exec.Command("kubectl", "create", "ns", namespace)
-		_, err := utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
 
-		By("labeling the namespace to enforce the restricted security policy")
-		cmd = exec.Command("kubectl", "label", "--overwrite", "ns", namespace,
-			"pod-security.kubernetes.io/enforce=restricted")
+		cmd := exec.Command(
+			"kubectl",
+			"create",
+			"ns",
+			namespace,
+		)
+
+		_, err := utils.Run(cmd)
+		Expect(err).NotTo(
+			HaveOccurred(),
+			"Failed to create namespace",
+		)
+
+		By(
+			"labeling the namespace to enforce the restricted security policy",
+		)
+
+		cmd = exec.Command(
+			"kubectl",
+			"label",
+			"--overwrite",
+			"ns",
+			namespace,
+			"pod-security.kubernetes.io/enforce=restricted",
+		)
+
 		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to label namespace with restricted policy")
+		Expect(err).NotTo(
+			HaveOccurred(),
+			"Failed to label namespace with restricted policy",
+		)
 
 		By("installing CRDs")
-		cmd = exec.Command("make", "install")
+
+		cmd = exec.Command(
+			"make",
+			"install",
+		)
+
 		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to install CRDs")
+		Expect(err).NotTo(
+			HaveOccurred(),
+			"Failed to install CRDs",
+		)
 
 		By("deploying the controller-manager")
-		cmd = exec.Command("make", "deploy", fmt.Sprintf("IMG=%s", managerImage))
+
+		cmd = exec.Command(
+			"make",
+			"deploy",
+			fmt.Sprintf(
+				"IMG=%s",
+				managerImage,
+			),
+		)
+
 		_, err = utils.Run(cmd)
-		Expect(err).NotTo(HaveOccurred(), "Failed to deploy the controller-manager")
+		Expect(err).NotTo(
+			HaveOccurred(),
+			"Failed to deploy the controller-manager",
+		)
 	})
 
-	// After all tests have been executed, clean up by undeploying the controller, uninstalling CRDs,
-	// and deleting the namespace.
 	AfterAll(func() {
-		By("cleaning up the curl pod for metrics")
-		cmd := exec.Command("kubectl", "delete", "pod", "curl-metrics", "-n", namespace)
+		By(
+			"cleaning up the curl pod for metrics",
+		)
+
+		cmd := exec.Command(
+			"kubectl",
+			"delete",
+			"pod",
+			"curl-metrics",
+			"-n",
+			namespace,
+		)
+
 		_, _ = utils.Run(cmd)
 
-		By("undeploying the controller-manager")
-		cmd = exec.Command("make", "undeploy")
+		By(
+			"cleaning up the metrics ClusterRoleBinding",
+		)
+
+		cmd = exec.Command(
+			"kubectl",
+			"delete",
+			"clusterrolebinding",
+			metricsRoleBindingName,
+			"--ignore-not-found",
+		)
+
+		_, _ = utils.Run(cmd)
+
+		By(
+			"undeploying the controller-manager",
+		)
+
+		cmd = exec.Command(
+			"make",
+			"undeploy",
+		)
+
 		_, _ = utils.Run(cmd)
 
 		By("uninstalling CRDs")
-		cmd = exec.Command("make", "uninstall")
+
+		cmd = exec.Command(
+			"make",
+			"uninstall",
+		)
+
 		_, _ = utils.Run(cmd)
 
 		By("removing manager namespace")
-		cmd = exec.Command("kubectl", "delete", "ns", namespace)
+
+		cmd = exec.Command(
+			"kubectl",
+			"delete",
+			"ns",
+			namespace,
+		)
+
 		_, _ = utils.Run(cmd)
 	})
 
-	// After each test, check for failures and collect logs, events,
-	// and pod descriptions for debugging.
 	AfterEach(func() {
 		specReport := CurrentSpecReport()
+
 		if specReport.Failed() {
-			By("Fetching controller manager pod logs")
-			cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
+			By(
+				"Fetching controller manager pod logs",
+			)
+
+			cmd := exec.Command(
+				"kubectl",
+				"logs",
+				controllerPodName,
+				"-n",
+				namespace,
+			)
+
 			controllerLogs, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Controller logs:\n %s", controllerLogs)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Controller logs:\n%s\n",
+					controllerLogs,
+				)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Controller logs: %s", err)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Failed to get Controller logs: %s\n",
+					err,
+				)
 			}
 
-			By("Fetching Kubernetes events")
-			cmd = exec.Command("kubectl", "get", "events", "-n", namespace, "--sort-by=.lastTimestamp")
+			By(
+				"Fetching Kubernetes events",
+			)
+
+			cmd = exec.Command(
+				"kubectl",
+				"get",
+				"events",
+				"-n",
+				namespace,
+				"--sort-by=.lastTimestamp",
+			)
+
 			eventsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Kubernetes events:\n%s", eventsOutput)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Kubernetes events:\n%s\n",
+					eventsOutput,
+				)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get Kubernetes events: %s", err)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Failed to get Kubernetes events: %s\n",
+					err,
+				)
 			}
 
-			By("Fetching curl-metrics logs")
-			cmd = exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
+			By(
+				"Fetching curl-metrics logs",
+			)
+
+			cmd = exec.Command(
+				"kubectl",
+				"logs",
+				"curl-metrics",
+				"-n",
+				namespace,
+			)
+
 			metricsOutput, err := utils.Run(cmd)
 			if err == nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Metrics logs:\n %s", metricsOutput)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Metrics logs:\n%s\n",
+					metricsOutput,
+				)
 			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Failed to get curl-metrics logs: %s", err)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Failed to get curl-metrics logs: %s\n",
+					err,
+				)
 			}
 
-			By("Fetching controller manager pod description")
-			cmd = exec.Command("kubectl", "describe", "pod", controllerPodName, "-n", namespace)
+			By(
+				"Fetching controller manager pod description",
+			)
+
+			cmd = exec.Command(
+				"kubectl",
+				"describe",
+				"pod",
+				controllerPodName,
+				"-n",
+				namespace,
+			)
+
 			podDescription, err := utils.Run(cmd)
 			if err == nil {
-				fmt.Println("Pod description:\n", podDescription)
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Pod description:\n%s\n",
+					podDescription,
+				)
 			} else {
-				fmt.Println("Failed to describe controller pod")
+				_, _ = fmt.Fprintf(
+					GinkgoWriter,
+					"Failed to describe controller pod: %s\n",
+					err,
+				)
 			}
 		}
 	})
 
-	SetDefaultEventuallyTimeout(2 * time.Minute)
-	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyTimeout(
+		2 * time.Minute,
+	)
+
+	SetDefaultEventuallyPollingInterval(
+		time.Second,
+	)
 
 	Context("Manager", func() {
-		It("should run successfully", func() {
-			By("validating that the controller-manager pod is running as expected")
-			verifyControllerUp := func(g Gomega) {
-				By("getting the name of the controller-manager pod")
-				cmd := exec.Command("kubectl", "get",
-					"pods", "-l", "control-plane=controller-manager",
-					"-o", "go-template={{ range .items }}"+
-						"{{ if not .metadata.deletionTimestamp }}"+
-						"{{ .metadata.name }}"+
-						"{{ \"\\n\" }}{{ end }}{{ end }}",
-					"-n", namespace,
+		It(
+			"should run successfully",
+			func() {
+				By(
+					"validating that the controller-manager pod is running as expected",
 				)
 
-				podOutput, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to retrieve controller-manager pod information")
-				podNames := utils.GetNonEmptyLines(podOutput)
-				g.Expect(podNames).To(HaveLen(1), "expected 1 controller pod running")
-				controllerPodName = podNames[0]
-				g.Expect(controllerPodName).To(ContainSubstring("controller-manager"))
+				verifyControllerUp := func(
+					g Gomega,
+				) {
+					cmd := exec.Command(
+						"kubectl",
+						"get",
+						"pods",
+						"-l",
+						"control-plane=controller-manager",
+						"-o",
+						"go-template={{ range .items }}"+
+							"{{ if not .metadata.deletionTimestamp }}"+
+							"{{ .metadata.name }}"+
+							"{{ \"\\n\" }}"+
+							"{{ end }}"+
+							"{{ end }}",
+						"-n",
+						namespace,
+					)
 
-				By("validating the pod's status")
-				cmd = exec.Command("kubectl", "get",
-					"pods", controllerPodName, "-o", "jsonpath={.status.phase}",
-					"-n", namespace,
+					podOutput, err :=
+						utils.Run(cmd)
+
+					g.Expect(err).NotTo(
+						HaveOccurred(),
+					)
+
+					podNames :=
+						utils.GetNonEmptyLines(
+							podOutput,
+						)
+
+					g.Expect(podNames).To(
+						HaveLen(1),
+					)
+
+					controllerPodName =
+						podNames[0]
+
+					g.Expect(
+						controllerPodName,
+					).To(
+						ContainSubstring(
+							"controller-manager",
+						),
+					)
+
+					cmd = exec.Command(
+						"kubectl",
+						"get",
+						"pods",
+						controllerPodName,
+						"-o",
+						"jsonpath={.status.phase}",
+						"-n",
+						namespace,
+					)
+
+					output, err :=
+						utils.Run(cmd)
+
+					g.Expect(err).NotTo(
+						HaveOccurred(),
+					)
+
+					g.Expect(output).To(
+						Equal("Running"),
+					)
+				}
+
+				Eventually(
+					verifyControllerUp,
+				).Should(
+					Succeed(),
 				)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Running"), "Incorrect controller-manager pod status")
-			}
-			Eventually(verifyControllerUp).Should(Succeed())
-		})
+			},
+		)
 
-		It("should ensure the metrics endpoint is serving metrics", func() {
-			By("creating a ClusterRoleBinding for the service account to allow access to metrics")
-			cmd := exec.Command("kubectl", "create", "clusterrolebinding", metricsRoleBindingName,
-				"--clusterrole=trussium-operator-metrics-reader",
-				fmt.Sprintf("--serviceaccount=%s:%s", namespace, serviceAccountName),
-			)
-			_, err := utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+		It(
+			"should ensure the metrics endpoint is serving metrics",
+			func() {
+				By(
+					"creating a ClusterRoleBinding for the service account to allow access to metrics",
+				)
 
-			By("validating that the metrics service is available")
-			cmd = exec.Command("kubectl", "get", "service", metricsServiceName, "-n", namespace)
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Metrics service should exist")
+				cmd := exec.Command(
+					"kubectl",
+					"create",
+					"clusterrolebinding",
+					metricsRoleBindingName,
+					"--clusterrole=trussium-operator-metrics-reader",
+					"--serviceaccount=trussium-operator-system:trussium-operator-controller-manager",
+				)
 
-			By("getting the service account token")
-			token, err := serviceAccountToken()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(token).NotTo(BeEmpty())
+				_, err := utils.Run(cmd)
 
-			By("ensuring the controller pod is ready")
-			verifyControllerPodReady := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pod", controllerPodName, "-n", namespace,
-					"-o", "jsonpath={.status.conditions[?(@.type=='Ready')].status}")
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("True"), "Controller pod not ready")
-			}
-			Eventually(verifyControllerPodReady, 3*time.Minute, time.Second).Should(Succeed())
+				Expect(err).NotTo(
+					HaveOccurred(),
+					"Failed to create ClusterRoleBinding",
+				)
 
-			By("verifying that the controller manager is serving the metrics server")
-			verifyMetricsServerStarted := func(g Gomega) {
-				cmd := exec.Command("kubectl", "logs", controllerPodName, "-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(ContainSubstring("Serving metrics server"),
-					"Metrics server not yet started")
-			}
-			Eventually(verifyMetricsServerStarted, 3*time.Minute, time.Second).Should(Succeed())
+				By(
+					"validating that the metrics service is available",
+				)
 
-			// +kubebuilder:scaffold:e2e-metrics-webhooks-readiness
+				cmd = exec.Command(
+					"kubectl",
+					"get",
+					"service",
+					metricsServiceName,
+					"-n",
+					namespace,
+				)
 
-			By("creating the curl-metrics pod to access the metrics endpoint")
-			cmd = exec.Command("kubectl", "run", "curl-metrics", "--restart=Never",
-				"--namespace", namespace,
-				"--image=curlimages/curl:latest",
-				"--overrides",
-				fmt.Sprintf(`{
-					"spec": {
-						"containers": [{
-							"name": "curl",
-							"image": "curlimages/curl:latest",
-							"command": ["/bin/sh", "-c"],
-							"args": [
-								"for i in $(seq 1 30); do curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"
-							],
-							"securityContext": {
-								"readOnlyRootFilesystem": true,
-								"allowPrivilegeEscalation": false,
-								"capabilities": {
-									"drop": ["ALL"]
-								},
-								"runAsNonRoot": true,
-								"runAsUser": 1000,
-								"seccompProfile": {
-									"type": "RuntimeDefault"
-								}
+				_, err = utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				By(
+					"getting the service account token",
+				)
+
+				token, err :=
+					serviceAccountToken()
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Expect(token).NotTo(
+					BeEmpty(),
+				)
+
+				By(
+					"ensuring the controller pod is ready",
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pod",
+							controllerPodName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("True"),
+						)
+					},
+					3*time.Minute,
+					time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				By(
+					"verifying that the controller manager is serving the metrics server",
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"logs",
+							controllerPodName,
+							"-n",
+							namespace,
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							ContainSubstring(
+								"Serving metrics server",
+							),
+						)
+					},
+					3*time.Minute,
+					time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				// +kubebuilder:scaffold:e2e-metrics-webhooks-readiness
+
+				By(
+					"creating the curl-metrics pod to access the metrics endpoint",
+				)
+
+				cmd = exec.Command(
+					"kubectl",
+					"run",
+					"curl-metrics",
+					"--restart=Never",
+					"--namespace",
+					namespace,
+					"--image=curlimages/curl:latest",
+					"--overrides",
+					fmt.Sprintf(
+						`{
+							"spec": {
+								"containers": [{
+									"name": "curl",
+									"image": "curlimages/curl:latest",
+									"command": ["/bin/sh", "-c"],
+									"args": [
+										"for i in $(seq 1 30); do curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"
+									],
+									"securityContext": {
+										"readOnlyRootFilesystem": true,
+										"allowPrivilegeEscalation": false,
+										"capabilities": {
+											"drop": ["ALL"]
+										},
+										"runAsNonRoot": true,
+										"runAsUser": 1000,
+										"seccompProfile": {
+											"type": "RuntimeDefault"
+										}
+									}
+								}],
+								"serviceAccountName": "%s"
 							}
-						}],
-						"serviceAccountName": "%s"
-					}
-				}`, token, metricsServiceName, namespace, serviceAccountName))
-			_, err = utils.Run(cmd)
-			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
+						}`,
+						token,
+						metricsServiceName,
+						namespace,
+						serviceAccountName,
+					),
+				)
 
-			By("waiting for the curl-metrics pod to complete.")
-			verifyCurlUp := func(g Gomega) {
-				cmd := exec.Command("kubectl", "get", "pods", "curl-metrics",
-					"-o", "jsonpath={.status.phase}",
-					"-n", namespace)
-				output, err := utils.Run(cmd)
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(output).To(Equal("Succeeded"), "curl pod in wrong status")
-			}
-			Eventually(verifyCurlUp, 5*time.Minute).Should(Succeed())
+				_, err = utils.Run(cmd)
 
-			By("getting the metrics by checking curl-metrics logs")
-			verifyMetricsAvailable := func(g Gomega) {
-				metricsOutput, err := getMetricsOutput()
-				g.Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-				g.Expect(metricsOutput).NotTo(BeEmpty())
-				g.Expect(metricsOutput).To(ContainSubstring("< HTTP/1.1 200 OK"))
-			}
-			Eventually(verifyMetricsAvailable, 2*time.Minute).Should(Succeed())
-		})
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"curl-metrics",
+							"-o",
+							"jsonpath={.status.phase}",
+							"-n",
+							namespace,
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("Succeeded"),
+						)
+					},
+					5*time.Minute,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						metricsOutput, err :=
+							getMetricsOutput()
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(
+							metricsOutput,
+						).To(
+							ContainSubstring(
+								"< HTTP/1.1 200 OK",
+							),
+						)
+					},
+					2*time.Minute,
+				).Should(
+					Succeed(),
+				)
+			},
+		)
+
+		It(
+			"should reconcile a TrussiumRuntime into managed Kubernetes resources",
+			func() {
+				runtimeManifest :=
+					fmt.Sprintf(`
+apiVersion: runtime.trussium.io/v1alpha1
+kind: TrussiumRuntime
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  image:
+    repository: %s
+    tag: %s
+    pullPolicy: IfNotPresent
+  replicas: 0
+  provider:
+    type: ollama
+    model: %s
+    baseURL: %s
+  service:
+    type: ClusterIP
+    port: 9000
+`,
+						runtimeResourceName,
+						namespace,
+						runtimeImageRepository,
+						initialRuntimeImageTag,
+						initialRuntimeModel,
+						initialRuntimeProviderBaseURL,
+					)
+
+				cmd := exec.Command(
+					"kubectl",
+					"apply",
+					"-f",
+					"-",
+				)
+
+				cmd.Stdin =
+					strings.NewReader(
+						runtimeManifest,
+					)
+
+				_, err := utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				managedResources := []string{
+					"configmap",
+					"serviceaccount",
+					"service",
+					"deployment",
+					"poddisruptionbudget",
+				}
+
+				for _, resourceType := range managedResources {
+					resourceType := resourceType
+
+					Eventually(
+						func(g Gomega) {
+							cmd := exec.Command(
+								"kubectl",
+								"get",
+								resourceType,
+								runtimeResourceName,
+								"-n",
+								namespace,
+							)
+
+							_, err :=
+								utils.Run(cmd)
+
+							g.Expect(err).NotTo(
+								HaveOccurred(),
+							)
+						},
+					).Should(
+						Succeed(),
+					)
+				}
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"deployment",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.spec.replicas}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("0"),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+
+				for _, resourceType := range managedResources {
+					resourceType := resourceType
+
+					Eventually(
+						func(g Gomega) {
+							cmd := exec.Command(
+								"kubectl",
+								"get",
+								resourceType,
+								runtimeResourceName,
+								"-n",
+								namespace,
+								"-o",
+								"jsonpath={.metadata.ownerReferences[0].kind}/{.metadata.ownerReferences[0].name}",
+							)
+
+							output, err :=
+								utils.Run(cmd)
+
+							g.Expect(err).NotTo(
+								HaveOccurred(),
+							)
+
+							g.Expect(output).To(
+								Equal(
+									"TrussiumRuntime/" +
+										runtimeResourceName,
+								),
+							)
+						},
+					).Should(
+						Succeed(),
+					)
+				}
+			},
+		)
+
+		It(
+			"should run a real Trussium runtime pod and satisfy its health probes",
+			func() {
+				cmd := exec.Command(
+					"kubectl",
+					"patch",
+					"trussiumruntime",
+					runtimeResourceName,
+					"-n",
+					namespace,
+					"--type=merge",
+					"-p",
+					`{"spec":{"replicas":1}}`,
+				)
+
+				_, err := utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"deployment",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.availableReplicas}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("1"),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				var runtimePodName string
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"-n",
+							namespace,
+							"-l",
+							fmt.Sprintf(
+								"app.kubernetes.io/instance=%s",
+								runtimeResourceName,
+							),
+							"-o",
+							"jsonpath={.items[0].metadata.name}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).NotTo(
+							BeEmpty(),
+						)
+
+						runtimePodName =
+							output
+					},
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pod",
+							runtimePodName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("True"),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				cmd = exec.Command(
+					"kubectl",
+					"get",
+					"deployment",
+					runtimeResourceName,
+					"-n",
+					namespace,
+					"-o",
+					"jsonpath={.spec.template.spec.containers[?(@.name=='trussium')].image}",
+				)
+
+				output, err :=
+					utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Expect(output).To(
+					Equal(runtimeImage),
+				)
+
+				probePaths := map[string]string{
+					"startupProbe":   "/health/live",
+					"livenessProbe":  "/health/live",
+					"readinessProbe": "/health/ready",
+				}
+
+				for probe, expectedPath := range probePaths {
+					cmd = exec.Command(
+						"kubectl",
+						"get",
+						"deployment",
+						runtimeResourceName,
+						"-n",
+						namespace,
+						"-o",
+						fmt.Sprintf(
+							"jsonpath={.spec.template.spec.containers[?(@.name=='trussium')].%s.httpGet.path}",
+							probe,
+						),
+					)
+
+					output, err =
+						utils.Run(cmd)
+
+					Expect(err).NotTo(
+						HaveOccurred(),
+					)
+
+					Expect(output).To(
+						Equal(expectedPath),
+					)
+
+					cmd = exec.Command(
+						"kubectl",
+						"get",
+						"deployment",
+						runtimeResourceName,
+						"-n",
+						namespace,
+						"-o",
+						fmt.Sprintf(
+							"jsonpath={.spec.template.spec.containers[?(@.name=='trussium')].%s.httpGet.port}",
+							probe,
+						),
+					)
+
+					output, err =
+						utils.Run(cmd)
+
+					Expect(err).NotTo(
+						HaveOccurred(),
+					)
+
+					Expect(output).To(
+						Equal("http"),
+					)
+				}
+			},
+		)
+
+		It(
+			"should roll the runtime pod when provider configuration changes",
+			func() {
+				var previousPodName string
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"-n",
+							namespace,
+							"-l",
+							fmt.Sprintf(
+								"app.kubernetes.io/instance=%s",
+								runtimeResourceName,
+							),
+							"-o",
+							"go-template={{ range .items }}"+
+								"{{ if not .metadata.deletionTimestamp }}"+
+								"{{ .metadata.name }}"+
+								"{{ \"\\n\" }}"+
+								"{{ end }}"+
+								"{{ end }}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						podNames :=
+							utils.GetNonEmptyLines(
+								output,
+							)
+
+						g.Expect(podNames).To(
+							HaveLen(1),
+						)
+
+						previousPodName =
+							podNames[0]
+					},
+				).Should(
+					Succeed(),
+				)
+
+				cmd := exec.Command(
+					"kubectl",
+					"get",
+					"deployment",
+					runtimeResourceName,
+					"-n",
+					namespace,
+					"-o",
+					fmt.Sprintf(
+						"jsonpath={.spec.template.metadata.annotations.%s}",
+						strings.ReplaceAll(
+							runtimeConfigChecksumAnnotation,
+							".",
+							"\\.",
+						),
+					),
+				)
+
+				previousChecksum, err :=
+					utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Expect(
+					previousChecksum,
+				).NotTo(
+					BeEmpty(),
+				)
+
+				patch := fmt.Sprintf(
+					`{"spec":{"provider":{"baseURL":"%s"}}}`,
+					updatedRuntimeProviderBaseURL,
+				)
+
+				cmd = exec.Command(
+					"kubectl",
+					"patch",
+					"trussiumruntime",
+					runtimeResourceName,
+					"-n",
+					namespace,
+					"--type=merge",
+					"-p",
+					patch,
+				)
+
+				_, err = utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"configmap",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							fmt.Sprintf(
+								"jsonpath={.data.%s}",
+								strings.ReplaceAll(
+									runtimeProviderBaseURLEnvironment,
+									".",
+									"\\.",
+								),
+							),
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal(
+								updatedRuntimeProviderBaseURL,
+							),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+
+				var updatedChecksum string
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"deployment",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							fmt.Sprintf(
+								"jsonpath={.spec.template.metadata.annotations.%s}",
+								strings.ReplaceAll(
+									runtimeConfigChecksumAnnotation,
+									".",
+									"\\.",
+								),
+							),
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).NotTo(
+							BeEmpty(),
+						)
+
+						g.Expect(output).NotTo(
+							Equal(
+								previousChecksum,
+							),
+						)
+
+						updatedChecksum =
+							output
+					},
+				).Should(
+					Succeed(),
+				)
+
+				Expect(
+					updatedChecksum,
+				).NotTo(
+					Equal(previousChecksum),
+				)
+
+				cmd = exec.Command(
+					"kubectl",
+					"get",
+					"deployment",
+					runtimeResourceName,
+					"-n",
+					namespace,
+					"-o",
+					"jsonpath={.spec.template.spec.containers[?(@.name=='trussium')].image}",
+				)
+
+				output, err :=
+					utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Expect(output).To(
+					Equal(runtimeImage),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"deployment",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.metadata.generation}/{.status.observedGeneration}/{.status.updatedReplicas}/{.status.readyReplicas}/{.status.availableReplicas}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						parts :=
+							strings.Split(
+								output,
+								"/",
+							)
+
+						g.Expect(parts).To(
+							HaveLen(5),
+						)
+
+						g.Expect(parts[1]).To(
+							Equal(parts[0]),
+						)
+
+						g.Expect(parts[2]).To(
+							Equal("1"),
+						)
+
+						g.Expect(parts[3]).To(
+							Equal("1"),
+						)
+
+						g.Expect(parts[4]).To(
+							Equal("1"),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				var replacementPodName string
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"-n",
+							namespace,
+							"-l",
+							fmt.Sprintf(
+								"app.kubernetes.io/instance=%s",
+								runtimeResourceName,
+							),
+							"-o",
+							"go-template={{ range .items }}"+
+								"{{ if not .metadata.deletionTimestamp }}"+
+								"{{ .metadata.name }}"+
+								"{{ \"\\n\" }}"+
+								"{{ end }}"+
+								"{{ end }}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						podNames :=
+							utils.GetNonEmptyLines(
+								output,
+							)
+
+						replacementPodName = ""
+
+						for _, podName := range podNames {
+							if podName !=
+								previousPodName {
+								replacementPodName =
+									podName
+
+								break
+							}
+						}
+
+						g.Expect(
+							replacementPodName,
+						).NotTo(
+							BeEmpty(),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pod",
+							replacementPodName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("True"),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pod",
+							previousPodName,
+							"-n",
+							namespace,
+							"--ignore-not-found",
+							"-o",
+							"name",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(
+							strings.TrimSpace(
+								output,
+							),
+						).To(
+							BeEmpty(),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"-n",
+							namespace,
+							"-l",
+							fmt.Sprintf(
+								"app.kubernetes.io/instance=%s",
+								runtimeResourceName,
+							),
+							"-o",
+							"go-template={{ range .items }}"+
+								"{{ if not .metadata.deletionTimestamp }}"+
+								"{{ .metadata.name }}"+
+								"{{ \"\\n\" }}"+
+								"{{ end }}"+
+								"{{ end }}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						podNames :=
+							utils.GetNonEmptyLines(
+								output,
+							)
+
+						g.Expect(podNames).To(
+							ConsistOf(
+								replacementPodName,
+							),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+			},
+		)
+
+		It(
+			"should complete a real Trussium runtime image upgrade",
+			func() {
+				var previousPodName string
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"-n",
+							namespace,
+							"-l",
+							fmt.Sprintf(
+								"app.kubernetes.io/instance=%s",
+								runtimeResourceName,
+							),
+							"-o",
+							"go-template={{ range .items }}"+
+								"{{ if not .metadata.deletionTimestamp }}"+
+								"{{ .metadata.name }}"+
+								"{{ \"\\n\" }}"+
+								"{{ end }}"+
+								"{{ end }}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						podNames :=
+							utils.GetNonEmptyLines(
+								output,
+							)
+
+						g.Expect(podNames).To(
+							HaveLen(1),
+						)
+
+						previousPodName =
+							podNames[0]
+					},
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"trussiumruntime",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.lastSuccessfulImage}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal(runtimeImage),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+
+				patch := fmt.Sprintf(
+					`{"spec":{"image":{"tag":"%s"}}}`,
+					upgradedRuntimeImageTag,
+				)
+
+				cmd := exec.Command(
+					"kubectl",
+					"patch",
+					"trussiumruntime",
+					runtimeResourceName,
+					"-n",
+					namespace,
+					"--type=merge",
+					"-p",
+					patch,
+				)
+
+				_, err := utils.Run(cmd)
+
+				Expect(err).NotTo(
+					HaveOccurred(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"deployment",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.spec.template.spec.containers[?(@.name=='trussium')].image}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal(
+								upgradedRuntimeImage,
+							),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"events",
+							"-n",
+							namespace,
+							"--field-selector",
+							fmt.Sprintf(
+								"involvedObject.name=%s,reason=%s",
+								runtimeResourceName,
+								runtimeUpgradeStartedEvent,
+							),
+							"-o",
+							"jsonpath={.items[*].reason}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(
+							strings.Fields(
+								output,
+							),
+						).To(
+							ContainElement(
+								runtimeUpgradeStartedEvent,
+							),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"deployment",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.availableReplicas}/{.status.updatedReplicas}/{.status.replicas}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("1/1/1"),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				var upgradedPodName string
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pods",
+							"-n",
+							namespace,
+							"-l",
+							fmt.Sprintf(
+								"app.kubernetes.io/instance=%s",
+								runtimeResourceName,
+							),
+							"-o",
+							"go-template={{ range .items }}"+
+								"{{ if not .metadata.deletionTimestamp }}"+
+								"{{ .metadata.name }}"+
+								"{{ \"\\n\" }}"+
+								"{{ end }}"+
+								"{{ end }}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						podNames :=
+							utils.GetNonEmptyLines(
+								output,
+							)
+
+						for _, podName := range podNames {
+							if podName !=
+								previousPodName {
+								upgradedPodName =
+									podName
+
+								break
+							}
+						}
+
+						g.Expect(
+							upgradedPodName,
+						).NotTo(
+							BeEmpty(),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"pod",
+							upgradedPodName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.conditions[?(@.type=='Ready')].status}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal("True"),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"trussiumruntime",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.conditions[?(@.type=='Upgrading')].status}/{.status.conditions[?(@.type=='Upgrading')].reason}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(output).To(
+							Equal(
+								"False/" +
+									upgradeCompleteReason,
+							),
+						)
+					},
+					5*time.Minute,
+					2*time.Second,
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"trussiumruntime",
+							runtimeResourceName,
+							"-n",
+							namespace,
+							"-o",
+							"jsonpath={.status.desiredImage}/{.status.currentImage}/{.status.lastSuccessfulImage}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						expected :=
+							upgradedRuntimeImage +
+								"/" +
+								upgradedRuntimeImage +
+								"/" +
+								upgradedRuntimeImage
+
+						g.Expect(output).To(
+							Equal(expected),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+
+				Eventually(
+					func(g Gomega) {
+						cmd := exec.Command(
+							"kubectl",
+							"get",
+							"events",
+							"-n",
+							namespace,
+							"--field-selector",
+							fmt.Sprintf(
+								"involvedObject.name=%s,reason=%s",
+								runtimeResourceName,
+								runtimeUpgradeCompletedEvent,
+							),
+							"-o",
+							"jsonpath={.items[*].reason}",
+						)
+
+						output, err :=
+							utils.Run(cmd)
+
+						g.Expect(err).NotTo(
+							HaveOccurred(),
+						)
+
+						g.Expect(
+							strings.Fields(
+								output,
+							),
+						).To(
+							ContainElement(
+								runtimeUpgradeCompletedEvent,
+							),
+						)
+					},
+				).Should(
+					Succeed(),
+				)
+			},
+		)
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
-
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput, err := getMetricsOutput()
-		// Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
 	})
 })
 
-// serviceAccountToken returns a token for the specified service account in the given namespace.
-// It uses the Kubernetes TokenRequest API to generate a token by directly sending a request
-// and parsing the resulting token from the API response.
-func serviceAccountToken() (string, error) {
+func serviceAccountToken() (
+	string,
+	error,
+) {
 	const tokenRequestRawString = `{
 		"apiVersion": "authentication.k8s.io/v1",
 		"kind": "TokenRequest"
 	}`
 
-	By("creating temporary file to store the token request")
-	secretName := fmt.Sprintf("%s-token-request", serviceAccountName)
-	tokenRequestFile := filepath.Join("/tmp", secretName)
-	err := os.WriteFile(tokenRequestFile, []byte(tokenRequestRawString), os.FileMode(0o644))
+	secretName := fmt.Sprintf(
+		"%s-token-request",
+		serviceAccountName,
+	)
+
+	tokenRequestFile := filepath.Join(
+		"/tmp",
+		secretName,
+	)
+
+	err := os.WriteFile(
+		tokenRequestFile,
+		[]byte(tokenRequestRawString),
+		os.FileMode(0o644),
+	)
 	if err != nil {
 		return "", err
 	}
 
 	var out string
-	verifyTokenCreation := func(g Gomega) {
-		By("executing kubectl command to create the token")
-		cmd := exec.Command("kubectl", "create", "--raw", fmt.Sprintf(
-			"/api/v1/namespaces/%s/serviceaccounts/%s/token",
-			namespace,
-			serviceAccountName,
-		), "-f", tokenRequestFile)
 
-		output, err := cmd.CombinedOutput()
-		g.Expect(err).NotTo(HaveOccurred())
+	Eventually(
+		func(g Gomega) {
+			cmd := exec.Command(
+				"kubectl",
+				"create",
+				"--raw",
+				fmt.Sprintf(
+					"/api/v1/namespaces/%s/serviceaccounts/%s/token",
+					namespace,
+					serviceAccountName,
+				),
+				"-f",
+				tokenRequestFile,
+			)
 
-		By("parsing the JSON output to extract the token")
-		var token tokenRequest
-		err = json.Unmarshal(output, &token)
-		g.Expect(err).NotTo(HaveOccurred())
+			output, err :=
+				cmd.CombinedOutput()
 
-		out = token.Status.Token
-	}
-	Eventually(verifyTokenCreation).Should(Succeed())
+			g.Expect(err).NotTo(
+				HaveOccurred(),
+			)
+
+			var token tokenRequest
+
+			err = json.Unmarshal(
+				output,
+				&token,
+			)
+
+			g.Expect(err).NotTo(
+				HaveOccurred(),
+			)
+
+			out =
+				token.Status.Token
+		},
+	).Should(
+		Succeed(),
+	)
 
 	return out, err
 }
 
-// getMetricsOutput retrieves and returns the logs from the curl pod used to access the metrics endpoint.
-func getMetricsOutput() (string, error) {
-	By("getting the curl-metrics logs")
-	cmd := exec.Command("kubectl", "logs", "curl-metrics", "-n", namespace)
+func getMetricsOutput() (
+	string,
+	error,
+) {
+	cmd := exec.Command(
+		"kubectl",
+		"logs",
+		"curl-metrics",
+		"-n",
+		namespace,
+	)
+
 	return utils.Run(cmd)
 }
 
-// tokenRequest is a simplified representation of the Kubernetes TokenRequest API response,
-// containing only the token field that we need to extract.
 type tokenRequest struct {
 	Status struct {
 		Token string `json:"token"`


### PR DESCRIPTION
Closes #20

## Summary

Adds controller integration coverage and deterministic Kind end-to-end coverage for the TrussiumRuntime lifecycle.

## What changed

- Adds manager-driven envtest coverage for reconciliation, ownership, status, reference recovery, drift recreation, scale-to-zero, configuration rollouts, and image upgrades.
- Adds six Kind E2E specs for manager installation, metrics access, runtime readiness and probes, configuration rollouts, and image upgrades.
- Makes `make test-e2e` use an isolated Kind kubeconfig, skip unused CertManager setup, clean test resources, and collect diagnostics on CI failures.
- Documents the validation workflow and marks roadmap milestone O7 complete.

## Architecture / design notes

envtest tests run the actual controller through a controller-runtime Manager, while Kind tests cover Deployment and kubelet behavior unavailable in envtest. The rollout test changes `provider.baseURL` because it is projected into the managed ConfigMap and checksum.

## Testing

- Controller integration suite under `internal/controller/integration`
- Six-spec Kind E2E suite under `test/e2e`

## Validation

- `make test`
- `make lint`
- `make test-e2e`
- `go build -o /tmp/trussium-operator-manager ./cmd/main.go`
- `git diff --check`

## Documentation

Updated `README.md`, `DEVELOPMENT.md`, `ROADMAP.md`, and E2E CI failure diagnostics.

## Compatibility

- Operator, runtime, Kubernetes, and CRD/API compatibility: no change.

## Security

No security impact.

## Checklist

- [x] The change is scoped to the linked issue.
- [x] Tests cover the new behavior.
- [x] Generated artifacts are stable.
- [x] No credentials or sensitive information are included.
- [x] The pull request title follows Conventional Commits.