### PR TITLE
build: publish versioned installation bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,19 @@ jobs:
           update-file: VERSION
           allow-initial-development-versions: true
 
+      - name: Build installation bundle
+        if: steps.semantic-release.outputs.version != ''
+        env:
+          IMG: ghcr.io/${{ github.repository }}:v${{ steps.semantic-release.outputs.version }}
+        run: make build-installer IMG="$IMG"
+
+      - name: Upload installation bundle
+        if: steps.semantic-release.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: v${{ steps.semantic-release.outputs.version }}
+        run: gh release upload "$RELEASE_TAG" dist/install.yaml --clobber
+
       - name: Dispatch container publication
         if: steps.semantic-release.outputs.version != ''
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ go.work.sum
 
 # Local project tools and envtest binaries
 /bin/
+
+# Generated installation bundles
+/dist/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -139,6 +139,16 @@ Tagged releases publish multi-platform operator images to:
 ghcr.io/trussiumhq/trussium-operator:<version>
 ```
 
+Each GitHub release also includes `install.yaml`, a single manifest containing
+the CRD and controller deployment. Generate the equivalent local bundle with:
+
+```bash
+make build-installer IMG=ghcr.io/trussiumhq/trussium-operator:v0.1.0
+```
+
+The target writes `dist/install.yaml` and leaves the tracked Kustomize files
+unchanged.
+
 ## Release Versioning
 
 The operator follows Semantic Versioning and uses Conventional Commits to

--- a/Makefile
+++ b/Makefile
@@ -150,8 +150,12 @@ docker-buildx: ## Build and push docker image for the manager for cross-platform
 .PHONY: build-installer
 build-installer: manifests generate kustomize ## Generate a consolidated YAML with CRDs and deployment.
 	mkdir -p dist
-	cd config/manager && "$(KUSTOMIZE)" edit set image controller=${IMG}
-	"$(KUSTOMIZE)" build config/default > dist/install.yaml
+	@output="$(CURDIR)/dist/install.yaml"; \
+	tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	cp -R config "$$tmpdir/config"; \
+	cd "$$tmpdir/config/manager" && "$(KUSTOMIZE)" edit set image controller=${IMG}; \
+	"$(KUSTOMIZE)" build "$$tmpdir/config/default" > "$$output"
 
 ##@ Deployment
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ The operator does not contain or compile the Trussium Python runtime. It
 consumes released runtime container images and manages their Kubernetes
 deployment lifecycle.
 
+## Installation
+
+Install a released operator version with its CRDs and controller deployment:
+
+```bash
+kubectl apply -f \
+  https://github.com/trussiumhq/trussium-operator/releases/download/v<version>/install.yaml
+```
+
+Replace `v<version>` with an operator release that includes the bundle. The
+release bundle pins the controller image to that same version.
+
 ## Custom Resource
 
 The initial API is:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,31 +12,15 @@ through GitHub Issues.
 
 ## Current Focus
 
-The runtime upgrade lifecycle and compatibility contract have been implemented.
+Milestones O1 through O7 are complete. The operator now has controller
+integration coverage, Kind end-to-end coverage, and a first automated release
+at `v0.1.0`.
 
-The operator now provides:
-
-- Desired runtime image reporting
-- Current Deployment image reporting
-- Last successful runtime image tracking
-- Explicit runtime image upgrade detection
-- `Upgrading` condition
-- Upgrade progress reporting
-- Upgrade completion reporting
-- Upgrade failure reporting
-- Deployment rollout completion detection
-- Deployment progress deadline handling
-- Replica failure handling
-- Scale-to-zero upgrade semantics
-- Deterministic runtime configuration checksums
-- Configuration-triggered Deployment rollouts
-- Runtime upgrade lifecycle Events
-- Pre-release operator/runtime compatibility documentation
-
-Upgrade observation remains Kubernetes-native and requires no direct Pod or
-ReplicaSet permissions.
-
-The next priority is controller integration and end-to-end testing.
+The current priority is Milestone O8: make the operator straightforward to
+install, upgrade, and consume as a released Kubernetes package. Release
+automation, multi-platform images, SBOMs, provenance, and CodeQL scanning are
+in place. The remaining work is installation packaging, release and upgrade
+guidance, and an explicit operator/runtime compatibility matrix.
 
 ---
 
@@ -528,23 +512,10 @@ Compatibility will be tracked by operator and runtime release:
 
 ## Immediate Priority
 
-The next priority is Milestone O7:
+Complete Milestone O8 in this order:
 
-1. Validate the operator against Kubernetes API machinery and real clusters.
-
-The next milestone will focus on:
-
-- envtest integration
-- CRD installation validation
-- Manager/controller integration
-- Managed-resource lifecycle tests
-- Status integration tests
-- Secret-reference integration tests
-- PodDisruptionBudget integration tests
-- Upgrade lifecycle integration tests
-- Kind-cluster installation
-- Real Deployment rollout validation
-- Runtime readiness validation
-- Configuration-triggered rollout validation
-- Runtime image upgrade validation
-- Garbage-collection validation
+1. Publish a versioned CRD installation bundle.
+2. Add a Helm chart for repeatable operator installation and upgrades.
+3. Document release consumption, upgrade steps, and operator/runtime
+   compatibility.
+4. Validate the packaged installation paths in CI.


### PR DESCRIPTION
Closes #24

## Summary

Adds a reproducible, version-pinned `install.yaml` asset to future Trussium Operator releases.

## What changed

- Makes `make build-installer` render through a temporary Kustomize copy, leaving tracked manifests unchanged.
- Builds bundles with the released controller image.
- Uploads the bundle to each semantic GitHub release.
- Documents versioned installation and updates O8 roadmap priority.

## Testing

- `make test`
- `make lint`
- Workflow YAML parsing
- `make build-installer IMG=ghcr.io/trussiumhq/trussium-operator:v0.1.0`
- `git diff --check`

## Compatibility

No CRD/API or runtime compatibility change.

## Security

No credentials are added; release upload uses the existing repository token.

## Checklist

- [x] The change is scoped to the linked issue.
- [x] Tests cover the new behaviour where applicable.
- [x] Generated artifacts are stable.
- [x] Public installation guidance is updated.
- [x] No credentials or sensitive information are included.
- [x] The pull request title follows Conventional Commits.