### PR TITLE
fix: document operator Helm registry

### DIFF
--- a/charts/trussium-operator/README.md
+++ b/charts/trussium-operator/README.md
@@ -15,7 +15,14 @@ helm install trussium-operator ./charts/trussium-operator \
   --create-namespace
 ```
 
-OCI distribution is added with the chart release automation.
+Released chart versions are available from the OCI registry:
+
+```bash
+helm install trussium-operator oci://ghcr.io/trussiumhq/charts/trussium-operator \
+  --version <version> \
+  --namespace trussium-operator-system \
+  --create-namespace
+```
 
 ## Configuration
 


### PR DESCRIPTION
Closes #30

## Summary

Documents the released OCI chart installation path and triggers the first chart publication release.

## Testing

- `make helm-lint`

## Compatibility

No API or runtime compatibility change.