### PR TITLE
docs: add operator upgrade guidance

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -29,24 +29,18 @@ Compatibility involves:
 - Runtime health endpoint compatibility
 - Container security and execution contract compatibility
 
-## Pre-Release Compatibility
+## Released Compatibility Matrix
 
-The operator is currently pre-release.
+The following combinations are validated by the operator's release and Kind
+test suites:
 
-A version-specific compatibility guarantee has therefore not yet been
-established.
+| Operator version | Kubernetes | Runtime image contract | Status |
+|---|---|---|---|
+| v0.3.1 | >=1.25 | documented v0.x Trussium runtime contract | Tested |
 
-Current compatibility status:
-
-| Operator version | Runtime versions | Status |
-|---|---|---|
-| Pre-release | Pre-release Trussium runtime releases | Development compatibility |
-
-`Development compatibility` means the repositories are being evolved together
-and validated against their documented integration contracts.
-
-It does not currently imply long-term backward or forward compatibility across
-arbitrary pre-release revisions.
+`Tested` means the operator lifecycle is validated against Kind and the
+documented runtime integration contract. It is not a promise that every
+arbitrary runtime tag is compatible.
 
 ## Runtime Contract Expected by the Operator
 
@@ -92,20 +86,6 @@ image based on:
 
 This avoids inventing compatibility guarantees before independent operator
 releases establish a stable versioning contract.
-
-## Future Compatibility Matrix
-
-Once the operator begins independently versioned releases, this document will
-track supported combinations explicitly.
-
-For example:
-
-| Operator version | Minimum runtime | Maximum tested runtime | Status |
-|---|---|---|---|
-| Future release | TBD | TBD | TBD |
-
-Exact ranges will be added only when verified by release and end-to-end
-testing.
 
 ## Upgrade Guidance
 

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -1,5 +1,29 @@
 # Runtime Upgrade Lifecycle
 
+## Operator Upgrade and Rollback
+
+Upgrade the operator independently from managed runtime images. The operator
+upgrade does not modify existing `TrussiumRuntime.spec.image` values.
+
+For the released manifest bundle, apply the target version:
+
+```bash
+kubectl apply -f https://github.com/trussiumhq/trussium-operator/releases/download/v0.3.1/install.yaml
+kubectl rollout status deployment/trussium-operator-controller-manager -n trussium-operator-system
+```
+
+For Helm installations, upgrade to an explicit chart version:
+
+```bash
+helm upgrade trussium-operator oci://ghcr.io/trussiumhq/charts/trussium-operator \
+  --version 0.3.1 --namespace trussium-operator-system
+```
+
+Before upgrading, review the target release notes and back up custom resources.
+Afterwards, confirm the controller Deployment is available and observe existing
+`TrussiumRuntime` conditions. To roll back, apply or upgrade to the previously
+known-good operator version; do not delete CRDs as part of a rollback.
+
 The Trussium Operator provides an explicit lifecycle for runtime image
 transitions managed through `TrussiumRuntime`.
 


### PR DESCRIPTION
Closes #32

## Summary

Documents operator installation upgrades, rollback, and the v0.3.1 compatibility matrix.

## What changed

- Adds manifest and Helm upgrade commands.
- Documents explicit rollback without CRD deletion.
- Records Kubernetes and runtime-contract compatibility.

## Validation

- `git diff --check`

## Compatibility

Documentation only; no API or runtime behavior change.