### PR TITLE
feat: support namespace-scoped reconciliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ operator-managed runtime instances. See
 [the chart documentation](charts/trussium-operator/README.md) for values and
 local installation.
 
+To limit reconciliation to a single tenant namespace, set the manager's
+`watchNamespace` Helm value. Leave it empty to watch all namespaces.
+
 ## Custom Resource
 
 The initial API is:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -429,10 +429,15 @@ Make the operator independently installable and releasable.
 
 ## Milestone O9 — Operational Extensions
 
-**Status:** 🗓 Planned
+**Status:** 🚧 In Progress
 
 Add operational features after the core API, reconciliation, upgrade, and
 packaging contracts are stable.
+
+### In Progress
+
+- Configurable manager watched namespace with Helm configuration and
+  all-namespaces default
 
 ### Potential Deliverables
 

--- a/charts/trussium-operator/README.md
+++ b/charts/trussium-operator/README.md
@@ -32,6 +32,10 @@ resource, pull-secret, and service-account settings through `values.yaml`.
 The controller mounts its ServiceAccount token because it must authenticate to
 the Kubernetes API; managed Trussium runtime Pods remain tokenless by default.
 
+Set `watchNamespace` to reconcile `TrussiumRuntime` resources in one namespace.
+The default empty value watches all namespaces. Namespace scoping limits the
+manager cache and watches; the chart's cluster-scoped RBAC remains unchanged.
+
 Validate local rendering with:
 
 ```bash

--- a/charts/trussium-operator/templates/deployment.yaml
+++ b/charts/trussium-operator/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
             - --leader-elect
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8443
+            {{- with .Values.watchNamespace }}
+            - {{ printf "--watch-namespace=%s" . | quote }}
+            {{- end }}
           image: {{ include "trussium-operator.image" . | quote }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/charts/trussium-operator/values.yaml
+++ b/charts/trussium-operator/values.yaml
@@ -38,3 +38,4 @@ metrics:
 nodeSelector: {}
 tolerations: []
 affinity: {}
+watchNamespace: ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -61,6 +62,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var watchNamespace string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -79,6 +81,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&watchNamespace, "watch-namespace", "", "Namespace to watch. Leave empty to watch all namespaces.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -154,7 +157,7 @@ func main() {
 		metricsServerOptions.KeyName = metricsCertKey
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	managerOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -172,7 +175,11 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+	if watchNamespace != "" {
+		managerOptions.Cache = cache.Options{DefaultNamespaces: map[string]cache.Config{watchNamespace: {}}}
+	}
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOptions)
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")
 		os.Exit(1)


### PR DESCRIPTION
Closes #38

## Summary

Adds opt-in manager namespace scoping with Helm configuration and documentation.

## What changed

- Adds `--watch-namespace`; empty keeps all-namespaces behavior.
- Scopes the controller-runtime cache when configured.
- Adds `watchNamespace` to the Helm chart.
- Updates README, chart docs, and the O9 roadmap state.

## Testing

- `go test ./cmd/...`
- `make test helm-lint`
- Helm rendering with `watchNamespace=tenant-a`
- `git diff --check`

## Compatibility

Existing installations remain cluster-wide by default.

## Security

Watch scope narrows the manager cache; cluster-scoped RBAC remains unchanged.