### PR TITLE
feat: add operator ServiceMonitor integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ local installation.
 To limit reconciliation to a single tenant namespace, set the manager's
 `watchNamespace` Helm value. Leave it empty to watch all namespaces.
 
+For Prometheus Operator installations, the Helm chart can optionally create a
+ServiceMonitor for the authenticated HTTPS metrics endpoint. See the chart
+documentation for its TLS configuration requirements.
+
 ## Custom Resource
 
 The initial API is:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -438,6 +438,7 @@ packaging contracts are stable.
 
 - Configurable manager watched namespace with Helm configuration and
   all-namespaces default
+- Optional Prometheus ServiceMonitor integration for operator metrics
 
 ### Potential Deliverables
 

--- a/charts/trussium-operator/README.md
+++ b/charts/trussium-operator/README.md
@@ -36,6 +36,13 @@ Set `watchNamespace` to reconcile `TrussiumRuntime` resources in one namespace.
 The default empty value watches all namespaces. Namespace scoping limits the
 manager cache and watches; the chart's cluster-scoped RBAC remains unchanged.
 
+## Prometheus ServiceMonitor
+
+Set `metrics.serviceMonitor.enabled=true` when the Prometheus Operator CRDs are
+installed. The ServiceMonitor scrapes the authenticated HTTPS metrics endpoint.
+Its default `insecureSkipVerify=true` supports the controller's self-signed
+certificate; set it to `false` only after configuring a trusted certificate.
+
 Validate local rendering with:
 
 ```bash

--- a/charts/trussium-operator/templates/servicemonitor.yaml
+++ b/charts/trussium-operator/templates/servicemonitor.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "trussium-operator.fullname" . }}-metrics
+  labels:
+    {{- include "trussium-operator.labels" . | nindent 4 }}
+spec:
+  endpoints:
+    - path: /metrics
+      port: https
+      scheme: https
+      interval: {{ .Values.metrics.serviceMonitor.interval | quote }}
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.metrics.serviceMonitor.insecureSkipVerify }}
+  selector:
+    matchLabels:
+      {{- include "trussium-operator.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/trussium-operator/values.yaml
+++ b/charts/trussium-operator/values.yaml
@@ -35,6 +35,10 @@ metrics:
     enabled: true
     type: ClusterIP
     port: 8443
+  serviceMonitor:
+    enabled: false
+    interval: 30s
+    insecureSkipVerify: true
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
Closes #40

## Summary

Adds optional Prometheus Operator ServiceMonitor support for operator metrics.

## What changed

- Adds a disabled-by-default ServiceMonitor Helm template.
- Adds service-monitor TLS and interval values.
- Documents prerequisites and self-signed certificate behavior.
- Updates O9 roadmap progress.

## Testing

- `make helm-lint`
- Helm rendering with `metrics.serviceMonitor.enabled=true`
- `git diff --check`

## Compatibility

Opt-in chart resource; existing installations are unchanged.

## Security

Metrics remain authenticated. The default TLS setting supports self-signed certificates and is documented.