### PR TITLE
docs: add project logo

### DIFF
--- a/.github/assets/trussium-logo.svg
+++ b/.github/assets/trussium-logo.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" role="img" aria-labelledby="title desc">
+  <title id="title">Trussium logo</title>
+  <desc id="desc">An abstract truss lattice in navy and teal.</desc>
+  <g fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M256 68 104 132 256 220 408 132 256 68Z" stroke="#00AFA8" stroke-width="34"/>
+    <path d="M104 132 256 220 408 132" stroke="#102F5B" stroke-width="34"/>
+    <path d="M104 132 178 350 256 444 334 350 408 132" stroke="#00AFA8" stroke-width="34"/>
+    <path d="M256 220V444" stroke="#102F5B" stroke-width="34"/>
+    <path d="M178 350 256 304 334 350" stroke="#102F5B" stroke-width="34"/>
+  </g>
+  <g fill="#102F5B" stroke="#00AFA8" stroke-width="10">
+    <circle cx="104" cy="132" r="25"/>
+    <circle cx="408" cy="132" r="25"/>
+    <circle cx="256" cy="220" r="27"/>
+    <circle cx="256" cy="444" r="25"/>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Trussium Operator
 
+<p align="center">
+  <img src=".github/assets/trussium-logo.svg" alt="Trussium logo" width="144">
+</p>
+
 The Trussium Operator is the Kubernetes-native lifecycle manager for
 [Trussium](https://github.com/trussium/trussium) runtime instances.
 


### PR DESCRIPTION
Adds the canonical Trussium SVG logo to the Operator README and repository assets.