### PR TITLE
feat: make leader election configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ failures.
 
 See [docs/STATUS_AND_EVENTS.md](docs/STATUS_AND_EVENTS.md).
 
+## High Availability
+
+The Helm chart enables controller leader election by default. Set
+`replicaCount` above one only with `leaderElection.enabled=true`, which ensures
+one active manager reconciles runtime resources at a time. See the
+[chart configuration](charts/trussium-operator/README.md#leader-election).
+
 ## Repository Responsibilities
 
 This repository owns:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -441,10 +441,10 @@ packaging contracts are stable.
 - Optional Prometheus ServiceMonitor integration for operator metrics
 - Opt-in runtime NetworkPolicy reconciliation with explicit ingress sources
 - Opt-in CPU-based HorizontalPodAutoscaler reconciliation
+- Configurable Helm leader election with an enabled-by-default HA-safe setting
 
 ### Potential Deliverables
 
-- Leader election
 - Configurable watched namespaces
 - Controller reconciliation metrics
 - ServiceMonitor integration

--- a/charts/trussium-operator/README.md
+++ b/charts/trussium-operator/README.md
@@ -36,6 +36,13 @@ Set `watchNamespace` to reconcile `TrussiumRuntime` resources in one namespace.
 The default empty value watches all namespaces. Namespace scoping limits the
 manager cache and watches; the chart's cluster-scoped RBAC remains unchanged.
 
+## Leader Election
+
+`leaderElection.enabled` defaults to `true`. Keep it enabled before increasing
+`replicaCount` above one: it ensures only one controller manager actively
+reconciles resources at a time. Set it to `false` only for a deliberate
+single-manager deployment.
+
 ## Prometheus ServiceMonitor
 
 Set `metrics.serviceMonitor.enabled=true` when the Prometheus Operator CRDs are

--- a/charts/trussium-operator/templates/deployment.yaml
+++ b/charts/trussium-operator/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
         - name: manager
           command: ["/manager"]
           args:
-            - --leader-elect
+            - --leader-elect={{ .Values.leaderElection.enabled }}
             - --health-probe-bind-address=:8081
             - --metrics-bind-address=:8443
             {{- with .Values.watchNamespace }}

--- a/charts/trussium-operator/values.yaml
+++ b/charts/trussium-operator/values.yaml
@@ -43,3 +43,6 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 watchNamespace: ""
+leaderElection:
+  # Keep a single active manager when more than one controller replica runs.
+  enabled: true

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -129,7 +129,7 @@ The operator manager will run:
 
 - As a non-root user
 - With minimum required Kubernetes permissions
-- With leader election in production
+- With configurable leader election, enabled by the Helm chart by default
 - With health and readiness endpoints
 - With structured controller-runtime logging
 
@@ -145,8 +145,8 @@ Runtime workloads support:
 - Graceful shutdown
 - Resource requests and limits
 
-The operator itself will use leader election when deployed with multiple
-replicas.
+The Helm chart enables leader election by default. Keep it enabled when the
+operator is deployed with multiple replicas.
 
 ## Deletion Model
 


### PR DESCRIPTION
Closes #48

## Summary

- expose the existing manager leader-election setting through Helm
- preserve enabled leader election as the chart default
- document safe multi-replica operator deployment and roadmap progress

## Validation

- make helm-lint
- helm template with leaderElection.enabled=true
- helm template with leaderElection.enabled=false
- git diff --check