### PR TITLE
feat: add controller reconciliation metrics

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -442,11 +442,11 @@ packaging contracts are stable.
 - Opt-in runtime NetworkPolicy reconciliation with explicit ingress sources
 - Opt-in CPU-based HorizontalPodAutoscaler reconciliation
 - Configurable Helm leader election with an enabled-by-default HA-safe setting
+- Bounded-cardinality controller reconciliation metrics
 
 ### Potential Deliverables
 
 - Configurable watched namespaces
-- Controller reconciliation metrics
 - ServiceMonitor integration
 - Runtime health aggregation
 - Provider configuration validation

--- a/docs/METRICS.md
+++ b/docs/METRICS.md
@@ -1,0 +1,16 @@
+# Controller Metrics
+
+The operator exposes authenticated HTTPS Prometheus metrics through its
+controller metrics Service. Enable the chart's optional ServiceMonitor when
+using Prometheus Operator.
+
+## Reconciliation Metrics
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `trussium_operator_runtime_reconciliations_total` | Counter | `result` | Completed reconciliation attempts. |
+| `trussium_operator_runtime_reconciliation_duration_seconds` | Histogram | `result` | Reconciliation duration. |
+
+`result` is either `success` or `error`. Metrics intentionally exclude resource
+name, namespace, image, Secret, and error-message labels to keep cardinality
+bounded and avoid exposing sensitive operational details.

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26.0
 require (
 	github.com/onsi/ginkgo/v2 v2.32.1
 	github.com/onsi/gomega v1.42.1
+	github.com/prometheus/client_golang v1.23.2
 	k8s.io/api v0.36.3
 	k8s.io/apiextensions-apiserver v0.36.3
 	k8s.io/apimachinery v0.36.3
@@ -44,12 +45,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	runtimeReconciliationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "trussium_operator",
+			Name:      "runtime_reconciliations_total",
+			Help:      "Total TrussiumRuntime reconciliation attempts by result.",
+		},
+		[]string{"result"},
+	)
+	runtimeReconciliationDurationSeconds = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "trussium_operator",
+			Name:      "runtime_reconciliation_duration_seconds",
+			Help:      "TrussiumRuntime reconciliation duration in seconds by result.",
+		},
+		[]string{"result"},
+	)
+)
+
+func init() {
+	ctrlmetrics.Registry.MustRegister(
+		runtimeReconciliationsTotal,
+		runtimeReconciliationDurationSeconds,
+	)
+}

--- a/internal/controller/metrics_test.go
+++ b/internal/controller/metrics_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestReconcileRecordsSuccessMetric(t *testing.T) {
+	before := testutil.ToFloat64(runtimeReconciliationsTotal.WithLabelValues("success"))
+	reconciler := TrussiumRuntimeReconciler{Client: fake.NewClientBuilder().WithScheme(newTestScheme(t)).Build(), Scheme: newTestScheme(t)}
+	if _, err := reconciler.Reconcile(context.Background(), ctrl.Request{}); err != nil {
+		t.Fatalf("reconcile missing resource: %v", err)
+	}
+	after := testutil.ToFloat64(runtimeReconciliationsTotal.WithLabelValues("success"))
+	if after != before+1 {
+		t.Fatalf("expected success metric increment, before=%v after=%v", before, after)
+	}
+}

--- a/internal/controller/trussiumruntime_controller.go
+++ b/internal/controller/trussiumruntime_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
@@ -63,7 +64,19 @@ type TrussiumRuntimeReconciler struct {
 func (r *TrussiumRuntimeReconciler) Reconcile(
 	ctx context.Context,
 	req ctrl.Request,
-) (ctrl.Result, error) {
+) (result ctrl.Result, reconcileErr error) {
+	startedAt := time.Now()
+
+	defer func() {
+		metricResult := "success"
+		if reconcileErr != nil {
+			metricResult = "error"
+		}
+
+		runtimeReconciliationsTotal.WithLabelValues(metricResult).Inc()
+		runtimeReconciliationDurationSeconds.WithLabelValues(metricResult).Observe(time.Since(startedAt).Seconds())
+	}()
+
 	logger := log.FromContext(ctx)
 
 	var runtimeResource runtimev1alpha1.TrussiumRuntime


### PR DESCRIPTION
Closes #53

## Summary

- record bounded success and error reconciliation counters and duration histograms
- register metrics with the authenticated controller metrics endpoint
- add focused metric coverage and operational documentation

## Validation

- make test
- bin/golangci-lint run
- git diff --check