### PR TITLE
docs: define advisory runtime compatibility policy

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -443,6 +443,7 @@ packaging contracts are stable.
 - Opt-in CPU-based HorizontalPodAutoscaler reconciliation
 - Configurable Helm leader election with an enabled-by-default HA-safe setting
 - Bounded-cardinality controller reconciliation metrics
+- Advisory-first runtime compatibility policy and maintained matrix guidance
 
 ### Potential Deliverables
 
@@ -452,7 +453,7 @@ packaging contracts are stable.
 - Provider configuration validation
 - Admission webhook
 - API conversion webhook
-- Runtime compatibility validation
+- Opt-in strict runtime compatibility mode after the matrix is mature
 
 Webhooks will not be added until schema validation is insufficient for a
 required invariant.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -75,8 +75,9 @@ A digest is treated as an immutable image identity.
 
 ## Enforcement
 
-The operator currently documents compatibility but does not reject a runtime
-image based on:
+The operator uses an advisory-first compatibility policy. It documents tested
+combinations and preserves support for compatible private mirrors, custom
+repositories, tags, and digests. It does not reject a runtime image based on:
 
 - Tag format
 - Semantic version
@@ -86,6 +87,16 @@ image based on:
 
 This avoids inventing compatibility guarantees before independent operator
 releases establish a stable versioning contract.
+
+## Future Strict Mode
+
+Strict compatibility enforcement is intentionally deferred. If introduced, it
+will be an explicit opt-in setting backed by a mature, maintained compatibility
+matrix. It must never silently change the current permissive default or block
+compatible private runtime builds.
+
+Until then, operators should use the released compatibility matrix as advisory
+guidance and observe `status.conditions` during image rollouts.
 
 ## Upgrade Guidance
 


### PR DESCRIPTION
Closes #55

## Summary

- document advisory-first runtime compatibility guidance
- preserve permissive support for compatible custom runtime images
- define future strict enforcement as an explicit opt-in mode
- align the operational roadmap with this policy

## Validation

- git diff --check