### PR TITLE
feat: add release-to-release upgrade smoke test

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -38,3 +38,27 @@ jobs:
         run: |
           helm uninstall trussium-operator --namespace trussium-operator-helm-test --ignore-not-found
           kubectl delete namespace trussium-operator-helm-test --ignore-not-found --wait=false
+
+  upgrade:
+    name: Release-to-release upgrade smoke test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: azure/setup-helm@v5
+      - uses: helm/kind-action@v1
+        with:
+          cluster_name: trussium-operator-upgrade-ci
+      - name: Run published-chart upgrade test
+        env:
+          PREVIOUS_CHART_VERSION: 0.3.1
+        run: scripts/chart-upgrade-smoke-test.sh
+      - name: Collect upgrade diagnostics on failure
+        if: failure()
+        run: |
+          kubectl get all -n trussium-operator-upgrade-test -o wide || true
+          kubectl get events -n trussium-operator-upgrade-test --sort-by=.lastTimestamp || true
+      - name: Clean up upgrade resources
+        if: always()
+        run: |
+          helm uninstall trussium-operator --namespace trussium-operator-upgrade-test --ignore-not-found
+          kubectl delete namespace trussium-operator-upgrade-test --ignore-not-found --wait=false

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -488,5 +488,5 @@ Compatibility will be tracked by operator and runtime release:
 
 ## Immediate Priority
 
-Begin Milestone O9 with operational features that have clear user demand and
-can be validated against the released packaging contract.
+Begin Milestone O10 with release-to-release upgrade confidence validated
+against published operator and chart artifacts.

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -376,3 +376,10 @@ This milestone does not provide:
 - Semantic-version admission
 - Secret-content-triggered rollouts
 - Direct application health probing by the controller
+
+## Release-to-Release Upgrade Validation
+
+CI installs a published previous operator chart in Kind, creates a
+`TrussiumRuntime`, upgrades to the checked-out chart, and confirms that the
+custom resource and controller rollout remain available. This validates the
+upgrade contract across released chart boundaries.

--- a/scripts/chart-upgrade-smoke-test.sh
+++ b/scripts/chart-upgrade-smoke-test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+namespace="trussium-operator-upgrade-test"
+release="trussium-operator"
+previous_version="${PREVIOUS_CHART_VERSION:-0.3.1}"
+previous_chart="/tmp/trussium-operator-${previous_version}.tgz"
+
+cleanup() {
+  helm uninstall "$release" --namespace "$namespace" --ignore-not-found
+  kubectl delete namespace "$namespace" --ignore-not-found --wait=false
+}
+trap cleanup EXIT
+
+helm pull "oci://ghcr.io/trussiumhq/charts/trussium-operator" --version "$previous_version" --destination /tmp
+helm install "$release" "$previous_chart" --namespace "$namespace" --create-namespace --wait --timeout=3m
+
+kubectl apply -f - <<'YAML'
+apiVersion: runtime.trussium.io/v1alpha1
+kind: TrussiumRuntime
+metadata:
+  name: upgrade-smoke
+  namespace: trussium-operator-upgrade-test
+spec:
+  image:
+    repository: ghcr.io/trussiumhq/trussium
+    tag: v0.24.0
+  provider:
+    type: ollama
+    model: llama3.2
+YAML
+
+kubectl get trussiumruntime upgrade-smoke --namespace "$namespace"
+helm upgrade "$release" charts/trussium-operator --namespace "$namespace" --wait --timeout=3m
+kubectl get trussiumruntime upgrade-smoke --namespace "$namespace"
+kubectl rollout status deployment/"$release-trussium-operator" --namespace "$namespace" --timeout=2m


### PR DESCRIPTION
Closes #59

## Summary

- add a Kind smoke test that installs the published v0.3.1 chart
- create a TrussiumRuntime and upgrade to the checked-out chart
- verify the resource and controller rollout remain available
- document the release-to-release upgrade contract and begin O10

## Validation

- bash -n scripts/chart-upgrade-smoke-test.sh
- helm lint charts/trussium-operator
- git diff --check