### PR TITLE
feat: expand release upgrade validation matrix

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -45,7 +45,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        previous_version: [0.3.1, 0.5.0, 0.7.0, 0.9.0]
+        include:
+          - previous_version: 0.3.1
+            namespace_suffix: 0-3-1
+          - previous_version: 0.5.0
+            namespace_suffix: 0-5-0
+          - previous_version: 0.7.0
+            namespace_suffix: 0-7-0
+          - previous_version: 0.9.0
+            namespace_suffix: 0-9-0
     steps:
       - uses: actions/checkout@v7
       - uses: azure/setup-helm@v5
@@ -55,15 +63,15 @@ jobs:
       - name: Run published-chart upgrade test
         env:
           PREVIOUS_CHART_VERSION: ${{ matrix.previous_version }}
-          UPGRADE_TEST_NAMESPACE: trussium-operator-upgrade-test-${{ matrix.previous_version }}
+          UPGRADE_TEST_NAMESPACE: trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}
         run: scripts/chart-upgrade-smoke-test.sh
       - name: Collect upgrade diagnostics on failure
         if: failure()
         run: |
-          kubectl get all -n "trussium-operator-upgrade-test-${{ matrix.previous_version }}" -o wide || true
-          kubectl get events -n "trussium-operator-upgrade-test-${{ matrix.previous_version }}" --sort-by=.lastTimestamp || true
+          kubectl get all -n "trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}" -o wide || true
+          kubectl get events -n "trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}" --sort-by=.lastTimestamp || true
       - name: Clean up upgrade resources
         if: always()
         run: |
-          helm uninstall trussium-operator --namespace "trussium-operator-upgrade-test-${{ matrix.previous_version }}" --ignore-not-found
-          kubectl delete namespace "trussium-operator-upgrade-test-${{ matrix.previous_version }}" --ignore-not-found --wait=false
+          helm uninstall trussium-operator --namespace "trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}" --ignore-not-found
+          kubectl delete namespace "trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}" --ignore-not-found --wait=false

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -40,8 +40,12 @@ jobs:
           kubectl delete namespace trussium-operator-helm-test --ignore-not-found --wait=false
 
   upgrade:
-    name: Release-to-release upgrade smoke test
+    name: Release upgrade matrix (${{ matrix.previous_version }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        previous_version: [0.3.1, 0.5.0, 0.7.0, 0.9.0]
     steps:
       - uses: actions/checkout@v7
       - uses: azure/setup-helm@v5
@@ -50,15 +54,16 @@ jobs:
           cluster_name: trussium-operator-upgrade-ci
       - name: Run published-chart upgrade test
         env:
-          PREVIOUS_CHART_VERSION: 0.3.1
+          PREVIOUS_CHART_VERSION: ${{ matrix.previous_version }}
+          UPGRADE_TEST_NAMESPACE: trussium-operator-upgrade-test-${{ matrix.previous_version }}
         run: scripts/chart-upgrade-smoke-test.sh
       - name: Collect upgrade diagnostics on failure
         if: failure()
         run: |
-          kubectl get all -n trussium-operator-upgrade-test -o wide || true
-          kubectl get events -n trussium-operator-upgrade-test --sort-by=.lastTimestamp || true
+          kubectl get all -n "trussium-operator-upgrade-test-${{ matrix.previous_version }}" -o wide || true
+          kubectl get events -n "trussium-operator-upgrade-test-${{ matrix.previous_version }}" --sort-by=.lastTimestamp || true
       - name: Clean up upgrade resources
         if: always()
         run: |
-          helm uninstall trussium-operator --namespace trussium-operator-upgrade-test --ignore-not-found
-          kubectl delete namespace trussium-operator-upgrade-test --ignore-not-found --wait=false
+          helm uninstall trussium-operator --namespace "trussium-operator-upgrade-test-${{ matrix.previous_version }}" --ignore-not-found
+          kubectl delete namespace "trussium-operator-upgrade-test-${{ matrix.previous_version }}" --ignore-not-found --wait=false

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -501,6 +501,8 @@ from one published chart version to a maintained compatibility matrix.
 - Runtime creation before upgrading to the checked-out chart
 - Post-upgrade custom-resource and controller-rollout verification
 - CI validation against published OCI chart artifacts
+- Representative published-version upgrade matrix in CI
+- Helm rollback verification after each matrix upgrade
 
 ### Next Priorities
 

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -19,6 +19,13 @@ helm upgrade trussium-operator oci://ghcr.io/trussiumhq/charts/trussium-operator
   --version 0.3.1 --namespace trussium-operator-system
 ```
 
+CI continuously validates release-to-release upgrades from representative
+published chart versions (`v0.3.1`, `v0.5.0`, `v0.7.0`, and `v0.9.0`) to the
+current chart. Each matrix entry creates a runtime, upgrades the operator,
+checks the managed resource and controller rollout, then rolls back to the
+previous chart revision and checks the rollout again. The matrix is updated
+as supported release families change.
+
 Before upgrading, review the target release notes and back up custom resources.
 Afterwards, confirm the controller Deployment is available and observe existing
 `TrussiumRuntime` conditions. To roll back, apply or upgrade to the previously

--- a/scripts/chart-upgrade-smoke-test.sh
+++ b/scripts/chart-upgrade-smoke-test.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-namespace="trussium-operator-upgrade-test"
-release="trussium-operator"
+namespace="${UPGRADE_TEST_NAMESPACE:-trussium-operator-upgrade-test}"
+release="${UPGRADE_TEST_RELEASE:-trussium-operator}"
 previous_version="${PREVIOUS_CHART_VERSION:-0.3.1}"
 previous_chart="/tmp/trussium-operator-${previous_version}.tgz"
 
@@ -15,12 +15,12 @@ trap cleanup EXIT
 helm pull "oci://ghcr.io/trussiumhq/charts/trussium-operator" --version "$previous_version" --destination /tmp
 helm install "$release" "$previous_chart" --namespace "$namespace" --create-namespace --wait --timeout=3m
 
-kubectl apply -f - <<'YAML'
+kubectl apply -f - <<YAML
 apiVersion: runtime.trussium.io/v1alpha1
 kind: TrussiumRuntime
 metadata:
   name: upgrade-smoke
-  namespace: trussium-operator-upgrade-test
+  namespace: ${namespace}
 spec:
   image:
     repository: ghcr.io/trussiumhq/trussium
@@ -32,5 +32,9 @@ YAML
 
 kubectl get trussiumruntime upgrade-smoke --namespace "$namespace"
 helm upgrade "$release" charts/trussium-operator --namespace "$namespace" --wait --timeout=3m
+kubectl get trussiumruntime upgrade-smoke --namespace "$namespace"
+kubectl rollout status deployment/"$release-trussium-operator" --namespace "$namespace" --timeout=2m
+
+helm rollback "$release" 1 --namespace "$namespace" --wait --timeout=3m
 kubectl get trussiumruntime upgrade-smoke --namespace "$namespace"
 kubectl rollout status deployment/"$release-trussium-operator" --namespace "$namespace" --timeout=2m


### PR DESCRIPTION
Closes #65

## Summary
- validate upgrades from representative published chart versions
- verify Helm rollback after each upgrade
- make upgrade smoke-test namespaces configurable for matrix jobs
- document the maintained O10 compatibility matrix

## Validation
- bash -n scripts/chart-upgrade-smoke-test.sh
- git diff --check