### PR TITLE
feat: publish upgrade compatibility matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,13 @@ jobs:
           CHART_VERSION: ${{ steps.semantic-release.outputs.version }}
         run: gh release upload "$RELEASE_TAG" "dist/trussium-operator-${CHART_VERSION}.tgz" --clobber
 
+      - name: Upload upgrade compatibility matrix
+        if: steps.semantic-release.outputs.version != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: v${{ steps.semantic-release.outputs.version }}
+        run: gh release upload "$RELEASE_TAG" docs/UPGRADE-MATRIX.md --clobber
+
       - name: Publish Helm chart to OCI registry
         if: steps.semantic-release.outputs.version != ''
         env:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -503,6 +503,7 @@ from one published chart version to a maintained compatibility matrix.
 - CI validation against published OCI chart artifacts
 - Representative published-version upgrade matrix in CI
 - Helm rollback verification after each matrix upgrade
+- Versioned upgrade matrix published with each operator release
 
 ### Next Priorities
 

--- a/docs/UPGRADE-MATRIX.md
+++ b/docs/UPGRADE-MATRIX.md
@@ -1,0 +1,16 @@
+# Operator Upgrade Compatibility Matrix
+
+This matrix is published with each operator release and records the chart
+versions exercised by the release-to-release upgrade workflow.
+
+| Target operator release | Previous chart versions tested | Rollback tested |
+| --- | --- | --- |
+| Current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
+
+Each entry installs the published previous chart from the Trussium OCI
+registry, creates a `TrussiumRuntime`, upgrades to the current chart, verifies
+the custom resource and controller rollout, then rolls back to the previous
+Helm revision and verifies the rollout again.
+
+This is an advisory compatibility record, not a guarantee for unlisted chart
+versions. The supported test points are expanded as release families change.

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -26,6 +26,9 @@ checks the managed resource and controller rollout, then rolls back to the
 previous chart revision and checks the rollout again. The matrix is updated
 as supported release families change.
 
+Each release also publishes the tested matrix as the
+`UPGRADE-MATRIX.md` release asset.
+
 Before upgrading, review the target release notes and back up custom resources.
 Afterwards, confirm the controller Deployment is available and observe existing
 `TrussiumRuntime` conditions. To roll back, apply or upgrade to the previously


### PR DESCRIPTION
Closes #67

## Summary
- add a versioned upgrade compatibility matrix release asset
- upload the matrix alongside installation bundles and Helm charts
- link the published asset from upgrade documentation
- record the O10 priority as delivered

## Validation
- git diff --check