### PR TITLE
process: establish cross-repository change management

### DIFF
--- a/.github/ISSUE_TEMPLATE/change_request.yml
+++ b/.github/ISSUE_TEMPLATE/change_request.yml
@@ -1,0 +1,79 @@
+name: Change request
+description: Propose a release-affecting or cross-repository change
+title: "change: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form for changes that may affect the runtime, runtime Helm
+        chart, operator, Kubernetes support, or upgrade behavior.
+
+  - type: dropdown
+    id: change-class
+    attributes:
+      label: Change class
+      options:
+        - Patch/security
+        - Compatible feature
+        - Contract change
+        - Breaking change
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem requires this change?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: Describe the intended behavior and user workflow.
+    validations:
+      required: true
+
+  - type: textarea
+    id: impact
+    attributes:
+      label: Compatibility impact
+      description: Address every dimension, using No impact where applicable.
+      value: |
+        - Runtime repository/image contract:
+        - Runtime Helm chart:
+        - Operator API/controller:
+        - Kubernetes versions:
+        - Upgrade/rollback:
+        - Security/RBAC/Secrets:
+        - Documentation/roadmap:
+    validations:
+      required: true
+
+  - type: textarea
+    id: rollout
+    attributes:
+      label: Rollout and rollback
+      description: State success conditions, rollback procedure, and migration limits.
+    validations:
+      required: true
+
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+      description: What should not be included in the first implementation?
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmation
+      options:
+        - label: I searched existing issues and roadmap items.
+          required: true
+        - label: I will update the compatibility manifest and documentation when applicable.
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,10 +40,13 @@ Describe documentation and roadmap updates.
 
 ## Compatibility
 
+- Change class: Patch/security, Compatible feature, Contract change, or Breaking change
 - Operator compatibility impact:
 - Trussium runtime compatibility impact:
+- Runtime Helm chart compatibility impact:
 - Kubernetes compatibility impact:
 - CRD/API compatibility impact:
+- Upgrade and rollback impact:
 
 ## Security
 
@@ -57,6 +60,13 @@ Describe any effect on:
 - Supply chain
 
 Write `No security impact` where applicable.
+
+## Change management
+
+- [ ] `docs/compatibility.yaml` is updated when release compatibility changes.
+- [ ] Rollout success conditions and rollback procedure are documented.
+- [ ] Runtime and runtime Helm chart changes have linked coordination issues or PRs.
+- [ ] Documentation and roadmap are updated.
 
 ## Checklist
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -511,3 +511,14 @@ The compatibility matrix is maintained as supported release families change.
 The next milestone will be planned only when a new API-level requirement is
 identified that cannot be handled by the current schema and reconciliation
 contracts.
+
+### Milestone O11 — Cross-Repository Change Management
+
+**Status:** 🚧 In Progress
+
+### Initial scope
+
+- Lightweight change classes and impact records
+- Machine-readable compatibility source of truth
+- Release and rollback gates for cross-repository changes
+- Runtime, chart, and operator coordination guidance

--- a/docs/CHANGE_MANAGEMENT.md
+++ b/docs/CHANGE_MANAGEMENT.md
@@ -69,3 +69,19 @@ tested release combinations. `COMPATIBILITY.md` and the published
 Runtime behavior remains authoritative in the runtime repository. Chart
 packaging and chart defaults remain authoritative in the runtime Helm
 repository.
+
+## Repository coordination
+
+The operator is independently released, but the following repositories define
+contracts it consumes:
+
+| Repository | Contract owned | Coordination trigger |
+|---|---|---|
+| `trussium` | Runtime image, APIs, environment, and health | Runtime contract or image change |
+| `trussium-helm` | Runtime chart and workload defaults | Chart, probe, resource, or configuration change |
+| `trussium-operator` | CRD, reconciliation, status, RBAC, and operator chart | Operator behavior or API change |
+
+Provider adapter and SDK repositories are coordinated conditionally when a
+change affects the runtime image, provider configuration, public API, or
+compatibility matrix. Consumer applications are not part of the core release
+gate unless their integration contract is changing.

--- a/docs/CHANGE_MANAGEMENT.md
+++ b/docs/CHANGE_MANAGEMENT.md
@@ -1,0 +1,71 @@
+# Change Management
+
+Trussium is released through three independently versioned repositories:
+
+- `trussium` — runtime behaviour and runtime image releases
+- `trussium-helm` — the runtime Helm distribution
+- `trussium-operator` — Kubernetes lifecycle and custom-resource behaviour
+
+This repository uses a lightweight change-management process to keep those
+contracts aligned without requiring a separate change-management system.
+
+## Change classes
+
+Every non-trivial issue and pull request declares one change class:
+
+- **Patch/security** — documentation, tests, dependency, or security fixes
+  without an intended public behaviour change.
+- **Compatible feature** — additive API, chart, or controller behaviour that
+  preserves existing valid resources and defaults.
+- **Contract change** — a change to runtime environment variables, health,
+  security defaults, packaging, or release compatibility.
+- **Breaking change** — removal or incompatible alteration of a public API,
+  chart value, managed-resource contract, or supported upgrade path.
+
+If multiple classes apply, use the highest-impact class.
+
+## Required impact record
+
+Issues and pull requests must record impact on:
+
+- Runtime repository and image contract
+- Runtime Helm chart
+- Operator API and controller behaviour
+- Kubernetes version support
+- Upgrade and rollback paths
+- Security, RBAC, and Secret handling
+- Documentation and roadmap
+
+An explicit `No impact` statement is required when a dimension is unaffected.
+
+## Release gates
+
+Before a compatible or contract change is released:
+
+1. The compatibility manifest is updated.
+2. Relevant runtime, chart, and operator tests pass.
+3. Upgrade and rollback behavior is validated when managed resources change.
+4. Public documentation and release notes are updated.
+5. A maintainer reviews the compatibility impact.
+
+Breaking changes additionally require a migration and deprecation plan before
+implementation.
+
+## Rollout and rollback
+
+Every release-affecting change documents its rollout success conditions, the
+previous known-good versions, the explicit rollback procedure, and any
+migration that rollback cannot reverse.
+
+The operator does not silently rewrite a user's runtime image or CRD during
+rollback.
+
+## Source of truth
+
+[`compatibility.yaml`](compatibility.yaml) is the machine-readable record of
+tested release combinations. `COMPATIBILITY.md` and the published
+`UPGRADE-MATRIX.md` asset must remain consistent with it.
+
+Runtime behavior remains authoritative in the runtime repository. Chart
+packaging and chart defaults remain authoritative in the runtime Helm
+repository.

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -31,12 +31,14 @@ Compatibility involves:
 
 ## Released Compatibility Matrix
 
-The following combinations are validated by the operator's release and Kind
-test suites:
+The machine-readable source of truth is
+[`compatibility.yaml`](compatibility.yaml). It records the currently validated
+operator, runtime image, chart, Kubernetes, upgrade, and rollback combinations.
+The following is the current release snapshot:
 
-| Operator version | Kubernetes | Runtime image contract | Status |
-|---|---|---|---|
-| v0.3.1 | >=1.25 | documented v0.x Trussium runtime contract | Tested |
+| Operator version | Runtime version | Runtime chart | Kubernetes | Status |
+|---|---|---|---|---|
+| v0.12.0 | v0.24.0 | v0.5.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -1,0 +1,29 @@
+schemaVersion: 1
+lastValidated: "2026-08-27"
+operator:
+  version: v0.12.0
+  repository: trussiumhq/trussium-operator
+runtime:
+  repository: trussiumhq/trussium
+  image: ghcr.io/trussiumhq/trussium
+  validatedVersions:
+    - version: v0.24.0
+      status: validated
+  candidates:
+    - version: v0.67.0
+      status: pending-validation
+chart:
+  repository: trussiumhq/trussium-helm
+  chart: trussium
+  version: v0.5.0
+  runtimeAppVersion: v0.24.0
+kubernetes:
+  minimumVersion: ">=1.25"
+upgrade:
+  previousOperatorChartVersions:
+    - v0.3.1
+    - v0.5.0
+    - v0.7.0
+    - v0.9.0
+  rollbackValidated: true
+  policy: advisory


### PR DESCRIPTION
Closes #77

## Summary
- define lightweight change classes and compatibility impact records
- add a machine-readable cross-repository compatibility manifest
- add change-request and pull-request release gates
- document rollout, rollback, and source-of-truth expectations
- begin Milestone O11 in the roadmap

## Validation
- Python YAML parse of docs/compatibility.yaml
- git diff --check