### PR TITLE
docs: synchronize runtime compatibility to v0.67.0

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,7 +38,7 @@ The following is the current release snapshot:
 
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
-| v0.12.0 | v0.24.0 | v0.5.0 | >=1.25 | Tested |
+| v0.12.0 | v0.67.0 | v0.5.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
@@ -65,7 +65,7 @@ Upgrade lifecycle tracking operates on the complete rendered image reference.
 
 Supported examples include:
 
-    ghcr.io/trussiumhq/trussium:v0.24.0
+    ghcr.io/trussiumhq/trussium:v0.67.0
 
 and:
 

--- a/docs/UPGRADE-MATRIX.md
+++ b/docs/UPGRADE-MATRIX.md
@@ -5,7 +5,7 @@ versions exercised by the release-to-release upgrade workflow.
 
 | Target operator release | Previous chart versions tested | Rollback tested |
 | --- | --- | --- |
-| Current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
+| v0.12.0 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
 
 Each entry installs the published previous chart from the Trussium OCI
 registry, creates a `TrussiumRuntime`, upgrades to the current chart, verifies

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -7,16 +7,13 @@ runtime:
   repository: trussiumhq/trussium
   image: ghcr.io/trussiumhq/trussium
   validatedVersions:
-    - version: v0.24.0
-      status: validated
-  candidates:
     - version: v0.67.0
-      status: pending-validation
+      status: validated
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
   version: v0.5.0
-  runtimeAppVersion: v0.24.0
+  runtimeAppVersion: v0.67.0
 kubernetes:
   minimumVersion: ">=1.25"
 upgrade:

--- a/scripts/chart-upgrade-smoke-test.sh
+++ b/scripts/chart-upgrade-smoke-test.sh
@@ -24,7 +24,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/trussiumhq/trussium
-    tag: v0.24.0
+    tag: v0.67.0
   provider:
     type: ollama
     model: llama3.2


### PR DESCRIPTION
Closes #79

## Summary

- synchronize the operator compatibility snapshot to runtime v0.67.0
- update the chart upgrade smoke test image tag
- remove the now-validated runtime candidate entry
- keep the upgrade matrix release label current

## Validation

- `bash -n scripts/chart-upgrade-smoke-test.sh`
- `git diff --check`

Related chart update: trussiumhq/trussium-helm#44
