### PR TITLE
docs: record Helm chart v0.6.0 compatibility

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,7 +38,7 @@ The following is the current release snapshot:
 
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
-| v0.12.0 | v0.67.0 | v0.5.0 | >=1.25 | Tested |
+| v0.12.0 | v0.67.0 | v0.6.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -12,7 +12,7 @@ runtime:
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
-  version: v0.5.0
+  version: v0.6.0
   runtimeAppVersion: v0.67.0
 kubernetes:
   minimumVersion: ">=1.25"


### PR DESCRIPTION
Closes #81

## Summary

- record the published Helm chart release v0.6.0
- keep the compatibility snapshot aligned with runtime v0.67.0

## Validation

- `bash -n scripts/chart-upgrade-smoke-test.sh`
- `git diff --check`
