### PR TITLE
feat: automate runtime compatibility proposals

### DIFF
--- a/.github/workflows/runtime-compatibility-proposal.yml
+++ b/.github/workflows/runtime-compatibility-proposal.yml
@@ -1,0 +1,72 @@
+name: Runtime compatibility proposal
+
+on:
+  repository_dispatch:
+    types:
+      - runtime-release
+  workflow_dispatch:
+    inputs:
+      runtime_version:
+        description: Runtime release tag (for example, v0.68.0)
+        required: true
+        type: string
+      runtime_image:
+        description: Immutable runtime image reference
+        required: true
+        type: string
+      release_url:
+        description: Runtime release URL
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  propose:
+    name: Open compatibility proposal
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Create a deduplicated proposal issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUNTIME_VERSION: ${{ github.event.client_payload.runtime_version || inputs.runtime_version }}
+          RUNTIME_IMAGE: ${{ github.event.client_payload.runtime_image || inputs.runtime_image }}
+          RELEASE_URL: ${{ github.event.client_payload.release_url || inputs.release_url }}
+          SOURCE_COMMIT: ${{ github.event.client_payload.source_commit || github.sha }}
+        run: |
+          set -eu
+
+          title="Runtime compatibility proposal: ${RUNTIME_VERSION}"
+          existing_count="$(gh issue list --state open --search "${title} in:title" --json number --jq 'length')"
+          if [ "$existing_count" -gt 0 ]; then
+            echo "An open proposal already exists for ${RUNTIME_VERSION}; nothing to do."
+            exit 0
+          fi
+
+          body_file="$(mktemp)"
+          trap 'rm -f "$body_file"' EXIT
+          cat >"$body_file" <<EOF
+          ## Runtime release detected
+
+          A new Trussium runtime release was published and needs an explicit compatibility review.
+
+          - Runtime version: \`${RUNTIME_VERSION}\`
+          - Runtime image: \`${RUNTIME_IMAGE}\`
+          - Source commit: \`${SOURCE_COMMIT}\`
+          - Release: ${RELEASE_URL:-not provided}
+
+          ## Required review
+
+          - Validate the runtime image against the operator lifecycle and upgrade matrix.
+          - Confirm the compatible Helm chart release and workload defaults.
+          - Update \`docs/compatibility.yaml\`, \`docs/COMPATIBILITY.md\`, and relevant smoke tests.
+          - Record rollout and rollback evidence before claiming the version as validated.
+
+          This issue is a proposal only. It does not change the operator image, CRD, runtime image,
+          or compatibility claims automatically.
+          EOF
+
+          gh issue create --title "$title" --body-file "$body_file"

--- a/docs/CHANGE_MANAGEMENT.md
+++ b/docs/CHANGE_MANAGEMENT.md
@@ -70,6 +70,19 @@ Runtime behavior remains authoritative in the runtime repository. Chart
 packaging and chart defaults remain authoritative in the runtime Helm
 repository.
 
+## Automated runtime-release proposals
+
+The `Runtime compatibility proposal` workflow listens for a `runtime-release`
+repository-dispatch event from `trussium`. It opens one deduplicated issue per
+runtime tag with the image, release URL, source commit, and required validation
+checklist. The workflow is proposal-only: a maintainer must validate the image,
+chart, upgrade path, and rollback evidence before updating the compatibility
+manifest.
+
+The runtime repository sends the event with its `PAT` secret. That token must
+be allowed to dispatch workflows in `trussiumhq/trussium-operator`; it is not
+stored in this repository and is never written into issue content.
+
 ## Repository coordination
 
 The operator is independently released, but the following repositories define


### PR DESCRIPTION
Closes #83

## Summary

- add a proposal-only repository-dispatch workflow for runtime releases
- deduplicate open compatibility proposals by runtime tag
- include image, release URL, source commit, and validation checklist
- document the cross-repository PAT and maintainer review boundary

## Validation

- Ruby YAML parse of the workflow
- `git diff --check`
- repository pre-commit checks
