### PR TITLE
docs: validate runtime 0.69.0 compatibility

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -64,6 +64,7 @@ jobs:
         env:
           PREVIOUS_CHART_VERSION: ${{ matrix.previous_version }}
           UPGRADE_TEST_NAMESPACE: trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}
+          TRUSSIUM_RUNTIME_TAG: 0.69.0
         run: scripts/chart-upgrade-smoke-test.sh
       - name: Collect upgrade diagnostics on failure
         if: failure()

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -514,7 +514,7 @@ contracts.
 
 ### Milestone O11 — Cross-Repository Change Management
 
-**Status:** 🚧 In Progress
+**Status:** ✅ Completed
 
 ### Initial scope
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,11 +38,14 @@ The following is the current release snapshot:
 
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
-| v0.12.0 | v0.67.0 | v0.6.0 | >=1.25 | Tested |
+| v0.13.1 | v0.69.0 | v0.10.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
 arbitrary runtime tag is compatible.
+
+The `0.69.0` validation uses an explicit runtime image override with chart
+`0.10.0`; that chart's built-in `appVersion` remains `0.67.0`.
 
 ## Runtime Contract Expected by the Operator
 
@@ -65,7 +68,7 @@ Upgrade lifecycle tracking operates on the complete rendered image reference.
 
 Supported examples include:
 
-    ghcr.io/trussiumhq/trussium:v0.67.0
+    ghcr.io/trussiumhq/trussium:0.69.0
 
 and:
 

--- a/docs/UPGRADE-MATRIX.md
+++ b/docs/UPGRADE-MATRIX.md
@@ -5,7 +5,7 @@ versions exercised by the release-to-release upgrade workflow.
 
 | Target operator release | Previous chart versions tested | Rollback tested |
 | --- | --- | --- |
-| v0.12.0 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
+| v0.13.1 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
 
 Each entry installs the published previous chart from the Trussium OCI
 registry, creates a `TrussiumRuntime`, upgrades to the current chart, verifies

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1
 lastValidated: "2026-08-27"
 operator:
-  version: v0.12.0
+  version: v0.13.1
   repository: trussiumhq/trussium-operator
 runtime:
   repository: trussiumhq/trussium
@@ -9,11 +9,15 @@ runtime:
   validatedVersions:
     - version: v0.67.0
       status: validated
+    - version: v0.69.0
+      imageTag: 0.69.0
+      status: validated
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
-  version: v0.6.0
+  version: v0.10.0
   runtimeAppVersion: v0.67.0
+  validatedRuntimeOverride: 0.69.0
 kubernetes:
   minimumVersion: ">=1.25"
 upgrade:

--- a/scripts/chart-upgrade-smoke-test.sh
+++ b/scripts/chart-upgrade-smoke-test.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 namespace="${UPGRADE_TEST_NAMESPACE:-trussium-operator-upgrade-test}"
 release="${UPGRADE_TEST_RELEASE:-trussium-operator}"
 previous_version="${PREVIOUS_CHART_VERSION:-0.3.1}"
+runtime_tag="${TRUSSIUM_RUNTIME_TAG:-0.67.0}"
 previous_chart="/tmp/trussium-operator-${previous_version}.tgz"
 
 cleanup() {
@@ -24,7 +25,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/trussiumhq/trussium
-    tag: v0.67.0
+    tag: ${runtime_tag}
   provider:
     type: ollama
     model: llama3.2


### PR DESCRIPTION
Closes #87

## Summary

Validate the operator against the published Trussium runtime `0.69.0` image
and record the compatibility evidence.

## Changes

- Record operator `v0.13.1`, runtime `v0.69.0`, and chart `0.10.0` in the
  compatibility source of truth.
- Record that validation uses the explicit runtime image tag `0.69.0` while
  the chart’s built-in app version remains `0.67.0`.
- Update compatibility and upgrade-matrix documentation.
- Make the upgrade smoke test runtime tag configurable and pin CI validation
  to `0.69.0`; retain the previous default for local compatibility runs.
- Mark cross-repository change management complete in the roadmap.

## Validation

- Published runtime image `ghcr.io/trussiumhq/trussium:0.69.0` pulled successfully.
- Isolated Kind upgrade smoke test passed using operator chart `0.9.0`:
  install, runtime reconciliation, upgrade, rollout, rollback, and cleanup.
- `make vet`
- `make test`
- `make lint`
- `helm lint charts/trussium-operator`
- `bash -n scripts/chart-upgrade-smoke-test.sh`
- `git diff --check`
- `docs/compatibility.yaml` YAML parse validation

## Compatibility impact

- Runtime: validated `0.69.0`; no runtime code changes.
- Helm chart: validates chart `0.10.0` with an explicit runtime image override;
  chart defaults remain organization-owned.
- Operator API/controller: unchanged.
- Kubernetes: unchanged (`>=1.25`).
- Upgrade/rollback: validated in isolated Kind.
- Security/RBAC/Secrets: unchanged.
- Documentation and roadmap: updated.
