### PR TITLE
chore: align operator with runtime 0.98.1

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           PREVIOUS_CHART_VERSION: ${{ matrix.previous_version }}
           UPGRADE_TEST_NAMESPACE: trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}
-          TRUSSIUM_RUNTIME_TAG: 0.98.0
+          TRUSSIUM_RUNTIME_TAG: 0.98.1
         run: scripts/chart-upgrade-smoke-test.sh
       - name: Collect upgrade diagnostics on failure
         if: failure()

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,13 +38,13 @@ The following is the current release snapshot:
 
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
-| v0.13.1 | v0.98.0 | v0.10.0 | >=1.25 | Tested |
+| v0.13.1 | v0.98.1 | v0.10.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
 arbitrary runtime tag is compatible.
 
-The `0.98.0` validation uses an explicit runtime image override with chart
+The `0.98.1` validation uses an explicit runtime image override with chart
 `0.10.0`, whose built-in `appVersion` is also `0.98.0`.
 
 ## Runtime Contract Expected by the Operator
@@ -68,7 +68,7 @@ Upgrade lifecycle tracking operates on the complete rendered image reference.
 
 Supported examples include:
 
-    ghcr.io/trussiumhq/trussium:0.98.0
+    ghcr.io/trussiumhq/trussium:0.98.1
 
 and:
 

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -12,15 +12,15 @@ runtime:
     - version: v0.69.0
       imageTag: 0.69.0
       status: validated
-    - version: v0.98.0
-      imageTag: 0.98.0
+    - version: v0.98.1
+      imageTag: 0.98.1
       status: validated
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
   version: v0.10.0
   runtimeAppVersion: v0.98.0
-  validatedRuntimeOverride: 0.98.0
+  validatedRuntimeOverride: 0.98.1
 kubernetes:
   minimumVersion: ">=1.25"
 upgrade:

--- a/scripts/chart-upgrade-smoke-test.sh
+++ b/scripts/chart-upgrade-smoke-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 namespace="${UPGRADE_TEST_NAMESPACE:-trussium-operator-upgrade-test}"
 release="${UPGRADE_TEST_RELEASE:-trussium-operator}"
 previous_version="${PREVIOUS_CHART_VERSION:-0.3.1}"
-runtime_tag="${TRUSSIUM_RUNTIME_TAG:-0.98.0}"
+runtime_tag="${TRUSSIUM_RUNTIME_TAG:-0.98.1}"
 previous_chart="/tmp/trussium-operator-${previous_version}.tgz"
 
 cleanup() {


### PR DESCRIPTION
Closes #120

## Summary

Align the operator compatibility baseline with patched runtime v0.98.1 and Helm chart v0.10.0.

## Changes

- Update compatibility documentation and machine-readable metadata.
- Update default upgrade smoke runtime tag.
- Preserve independent operator versioning and advisory policy.

## Validation

- Operator CI, Kind lifecycle, and release upgrade matrix.