### PR TITLE
fix: correct runtime app version metadata

### DIFF
--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -19,7 +19,7 @@ chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
   version: v0.10.0
-  runtimeAppVersion: v0.98.0
+  runtimeAppVersion: v0.98.1
   validatedRuntimeOverride: 0.98.1
 kubernetes:
   minimumVersion: ">=1.25"


### PR DESCRIPTION
Closes #122

## Summary

Correct the operator compatibility metadata to consistently record runtime v0.98.1.

## Validation

- Machine-readable compatibility metadata reviewed.
- Operator compatibility CI will validate the change.