### PR TITLE
feat!: validate stable runtime and chart 1.0.0

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           PREVIOUS_CHART_VERSION: ${{ matrix.previous_version }}
           UPGRADE_TEST_NAMESPACE: trussium-operator-upgrade-test-${{ matrix.namespace_suffix }}
-          TRUSSIUM_RUNTIME_TAG: 0.98.1
+          TRUSSIUM_RUNTIME_TAG: 1.0.0
         run: scripts/chart-upgrade-smoke-test.sh
       - name: Collect upgrade diagnostics on failure
         if: failure()

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -38,14 +38,14 @@ The following is the current release snapshot:
 
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
-| v0.13.1 | v0.98.1 | v0.10.0 | >=1.25 | Tested |
+| v1.0.0 | v1.0.0 | v1.0.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
 arbitrary runtime tag is compatible.
 
-The `0.98.1` validation uses an explicit runtime image override with chart
-`0.10.0`, whose built-in `appVersion` is also `0.98.0`.
+The `1.0.0` validation uses the stable runtime image and chart contract with
+an explicit runtime image override for lifecycle testing.
 
 ## Runtime Contract Expected by the Operator
 
@@ -68,7 +68,7 @@ Upgrade lifecycle tracking operates on the complete rendered image reference.
 
 Supported examples include:
 
-    ghcr.io/trussiumhq/trussium:0.98.1
+    ghcr.io/trussiumhq/trussium:1.0.0
 
 and:
 

--- a/docs/UPGRADE-MATRIX.md
+++ b/docs/UPGRADE-MATRIX.md
@@ -5,7 +5,7 @@ versions exercised by the release-to-release upgrade workflow.
 
 | Target operator release | Previous chart versions tested | Rollback tested |
 | --- | --- | --- |
-| v0.13.1 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
+| v1.0.0 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
 
 Each entry installs the published previous chart from the Trussium OCI
 registry, creates a `TrussiumRuntime`, upgrades to the current chart, verifies

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1
-lastValidated: "2026-08-27"
+lastValidated: "2026-08-31"
 operator:
-  version: v0.13.1
+  version: v1.0.0
   repository: trussiumhq/trussium-operator
 runtime:
   repository: trussiumhq/trussium
@@ -15,12 +15,15 @@ runtime:
     - version: v0.98.1
       imageTag: 0.98.1
       status: validated
+    - version: v1.0.0
+      imageTag: 1.0.0
+      status: validated
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
-  version: v0.10.0
-  runtimeAppVersion: v0.98.1
-  validatedRuntimeOverride: 0.98.1
+  version: v1.0.0
+  runtimeAppVersion: v1.0.0
+  validatedRuntimeOverride: 1.0.0
 kubernetes:
   minimumVersion: ">=1.25"
 upgrade:

--- a/scripts/chart-upgrade-smoke-test.sh
+++ b/scripts/chart-upgrade-smoke-test.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 namespace="${UPGRADE_TEST_NAMESPACE:-trussium-operator-upgrade-test}"
 release="${UPGRADE_TEST_RELEASE:-trussium-operator}"
 previous_version="${PREVIOUS_CHART_VERSION:-0.3.1}"
-runtime_tag="${TRUSSIUM_RUNTIME_TAG:-0.98.1}"
+runtime_tag="${TRUSSIUM_RUNTIME_TAG:-1.0.0}"
 previous_chart="/tmp/trussium-operator-${previous_version}.tgz"
 
 cleanup() {


### PR DESCRIPTION
Closes #127

## Summary

Validate the operator compatibility contract for Trussium runtime and Helm chart 1.0.0.

## Changes

- Record runtime image `ghcr.io/trussiumhq/trussium:1.0.0` as validated.
- Record Helm chart `v1.0.0` and runtime appVersion `v1.0.0`.
- Update the published compatibility matrix and upgrade matrix.
- Run upgrade smoke tests against runtime 1.0.0 by default.
- Promote the documented operator compatibility snapshot to 1.0.0.

## Validation

- `make test` (Go tests, vet, and generated assets)
- `git diff --check`
- `scripts/chart-upgrade-smoke-test.sh` (local Kind attempted; etcd timed out during installation; CI will provide the required cluster validation)

## Release notes

This is a deliberate breaking-change release trigger for operator 1.0.0.
The runtime-only and chart-only contracts remain independently documented.
