### PR TITLE
docs: propose runtime v1.17 compatibility

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -39,6 +39,7 @@ The following is the current release snapshot:
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
 | v1.0.0 | v1.0.0 | v1.0.0 | >=1.25 | Tested |
+| v1.0.0 | v1.17.0 | v1.1.0 | >=1.25 | Proposed |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
@@ -46,6 +47,10 @@ arbitrary runtime tag is compatible.
 
 The `1.0.0` validation uses the stable runtime image and chart contract with
 an explicit runtime image override for lifecycle testing.
+
+The `v1.17.0` / `v1.1.0` row is a compatibility proposal. It must not be
+treated as tested until the runtime workload reaches its health contract in a
+real Operator lifecycle test.
 
 ## Runtime Contract Expected by the Operator
 

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -18,12 +18,15 @@ runtime:
     - version: v1.0.0
       imageTag: 1.0.0
       status: validated
+    - version: v1.17.0
+      imageTag: 1.17.0
+      status: proposed
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
-  version: v1.0.0
-  runtimeAppVersion: v1.0.0
-  validatedRuntimeOverride: 1.0.0
+  version: v1.1.0
+  runtimeAppVersion: v1.17.0
+  validatedRuntimeOverride: 1.17.0
 kubernetes:
   minimumVersion: ">=1.25"
 upgrade:


### PR DESCRIPTION
Closes #147

## Summary
- record runtime v1.17.0 and Helm chart v1.1.0 as a compatibility proposal
- preserve the existing tested v1.0.0 matrix row
- explicitly require a real runtime health/lifecycle validation before claiming tested support

## Validation
- git diff --check
- compatibility metadata reviewed

## Documentation
- docs/compatibility.yaml updated
- docs/COMPATIBILITY.md updated