### PR TITLE
docs: validate runtime v1.17 compatibility

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -39,7 +39,7 @@ The following is the current release snapshot:
 | Operator version | Runtime version | Runtime chart | Kubernetes | Status |
 |---|---|---|---|---|
 | v1.0.0 | v1.0.0 | v1.0.0 | >=1.25 | Tested |
-| v1.0.0 | v1.17.0 | v1.1.0 | >=1.25 | Proposed |
+| v1.0.0 | v1.17.0 | v1.1.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
@@ -48,9 +48,9 @@ arbitrary runtime tag is compatible.
 The `1.0.0` validation uses the stable runtime image and chart contract with
 an explicit runtime image override for lifecycle testing.
 
-The `v1.17.0` / `v1.1.0` row is a compatibility proposal. It must not be
-treated as tested until the runtime workload reaches its health contract in a
-real Operator lifecycle test.
+The `v1.17.0` / `v1.1.0` row is validated by the real Operator E2E lifecycle:
+the runtime workload is reconciled, reaches its health contract, and survives
+the tested image upgrade path in Kind.
 
 ## Runtime Contract Expected by the Operator
 

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -1,5 +1,5 @@
 schemaVersion: 1
-lastValidated: "2026-08-31"
+lastValidated: "2026-09-02"
 operator:
   version: v1.0.0
   repository: trussiumhq/trussium-operator
@@ -20,7 +20,7 @@ runtime:
       status: validated
     - version: v1.17.0
       imageTag: 1.17.0
-      status: proposed
+      status: validated
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium


### PR DESCRIPTION
Closes #147

## Summary
- promote runtime v1.17.0 and Helm chart v1.1.0 from Proposed to Tested
- record validation date and real Operator E2E evidence

## Validation
- runtime image reached its health contract in the Operator lifecycle
- runtime image upgrade path passed in Kind
- full Operator CI, upgrade matrix, and CodeQL passed
- git diff --check

## Documentation
- docs/compatibility.yaml updated
- docs/COMPATIBILITY.md updated