### PR TITLE
docs: propose runtime 1.22 compatibility

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -40,6 +40,7 @@ The following is the current release snapshot:
 |---|---|---|---|---|
 | v1.0.0 | v1.0.0 | v1.0.0 | >=1.25 | Tested |
 | v1.0.0 | v1.17.0 | v1.1.0 | >=1.25 | Tested |
+| v1.0.1 | v1.22.0 | v1.1.0 | >=1.25 | Proposed |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
@@ -48,9 +49,10 @@ arbitrary runtime tag is compatible.
 The `1.0.0` validation uses the stable runtime image and chart contract with
 an explicit runtime image override for lifecycle testing.
 
-The `v1.17.0` / `v1.1.0` row is validated by the real Operator E2E lifecycle:
+The `v1.17.0` / `v1.1.0` row is validated by the real Operator E2E lifecycle;
 the runtime workload is reconciled, reaches its health contract, and survives
-the tested image upgrade path in Kind.
+the tested image upgrade path in Kind. The `v1.22.0` row is proposed and is
+not yet a tested compatibility claim.
 
 ## Runtime Contract Expected by the Operator
 

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -1,7 +1,7 @@
 schemaVersion: 1
 lastValidated: "2026-09-02"
 operator:
-  version: v1.0.0
+  version: v1.0.1
   repository: trussiumhq/trussium-operator
 runtime:
   repository: trussiumhq/trussium
@@ -21,6 +21,9 @@ runtime:
     - version: v1.17.0
       imageTag: 1.17.0
       status: validated
+    - version: v1.22.0
+      imageTag: 1.22.0
+      status: proposed
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium


### PR DESCRIPTION
Closes #159

## Summary

Record Operator v1.0.1 compatibility with runtime v1.22.0 as a proposed validation target.

## Changes

- Add runtime v1.22.0 to the machine-readable matrix with `proposed` status.
- Refresh the current Operator version to v1.0.1.
- Document that v1.17.0 remains the latest tested runtime/chart pair.
- Preserve clear promotion criteria so proposed entries are not presented as tested claims.

## Validation

- `git diff --check`
- Documentation-only change; runtime compatibility promotion requires the real Kind lifecycle workflow.
