### PR TITLE
test: validate runtime 1.22 upgrade

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -45,8 +45,8 @@ const (
 
 	runtimeImageRepository = "ghcr.io/trussiumhq/trussium"
 
-	initialRuntimeImageTag  = "0.23.0"
-	upgradedRuntimeImageTag = "0.24.0"
+	initialRuntimeImageTag  = "1.17.0"
+	upgradedRuntimeImageTag = "1.22.0"
 
 	runtimeImage = runtimeImageRepository + ":" + initialRuntimeImageTag
 


### PR DESCRIPTION
Closes #161

## Summary

Update the real Operator Kind E2E upgrade path to validate runtime v1.17.0 → v1.22.0.

## Changes

- Replace historical runtime tags in the E2E lifecycle test.
- Preserve rollout, health, and upgrade event assertions.

## Validation

- `gofmt`
- `go test ./api/... ./cmd/... ./internal/controller ./test/utils/...`
- Full Kind E2E runs in CI with the repository-managed cluster setup.

## Compatibility

The compatibility matrix remains Proposed for v1.22.0 until this E2E workflow passes.
