### PR TITLE
docs: validate runtime 1.22 compatibility

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -40,7 +40,7 @@ The following is the current release snapshot:
 |---|---|---|---|---|
 | v1.0.0 | v1.0.0 | v1.0.0 | >=1.25 | Tested |
 | v1.0.0 | v1.17.0 | v1.1.0 | >=1.25 | Tested |
-| v1.0.1 | v1.22.0 | v1.1.0 | >=1.25 | Proposed |
+| v1.0.1 | v1.22.0 | v1.1.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
@@ -51,8 +51,8 @@ an explicit runtime image override for lifecycle testing.
 
 The `v1.17.0` / `v1.1.0` row is validated by the real Operator E2E lifecycle;
 the runtime workload is reconciled, reaches its health contract, and survives
-the tested image upgrade path in Kind. The `v1.22.0` row is proposed and is
-not yet a tested compatibility claim.
+the tested image upgrade path in Kind. The `v1.22.0` row is validated by the
+real Operator E2E lifecycle upgrade.
 
 ## Runtime Contract Expected by the Operator
 

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -23,7 +23,7 @@ runtime:
       status: validated
     - version: v1.22.0
       imageTag: 1.22.0
-      status: proposed
+      status: validated
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium


### PR DESCRIPTION
Closes #159

## Summary

Promote the runtime v1.22.0 compatibility entry after the real Kind E2E lifecycle passed in PR #162.

## Changes

- Mark Operator v1.0.1 / runtime v1.22.0 / Helm v1.1.0 as Tested.
- Record the E2E validation evidence in the compatibility guide.

## Validation

- PR #162 Kind lifecycle smoke test passed.
- PR #162 upgrade matrices and all required Operator checks passed.
