### PR TITLE
docs: refresh Operator task examples

### DIFF
--- a/docs/CUSTOM_RESOURCE.md
+++ b/docs/CUSTOM_RESOURCE.md
@@ -27,7 +27,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/trussiumhq/trussium
-    tag: v0.1.0
+    tag: v1.22.0
 
   provider:
     type: ollama
@@ -119,7 +119,7 @@ Tag example:
 ```yaml
 image:
   repository: ghcr.io/trussiumhq/trussium
-  tag: v0.10.0
+  tag: v1.22.0
 ```
 
 Digest example:
@@ -300,7 +300,7 @@ status:
   observedGeneration: 3
   readyReplicas: 2
   availableReplicas: 2
-  currentImage: ghcr.io/trussiumhq/trussium:v0.10.0
+  currentImage: ghcr.io/trussiumhq/trussium:v1.22.0
   endpoint: http://private-ai.trussium.svc.cluster.local:9000
   conditions:
     - type: Ready
@@ -326,7 +326,7 @@ Fully rendered image requested by the current `spec.image`.
 
 Example:
 
-    ghcr.io/trussiumhq/trussium:v0.24.0
+    ghcr.io/trussiumhq/trussium:v1.22.0
 
 ### `status.currentImage`
 

--- a/docs/RECONCILIATION.md
+++ b/docs/RECONCILIATION.md
@@ -171,7 +171,7 @@ The managed Deployment:
 
 Tag-based image example:
 
-    ghcr.io/trussiumhq/trussium:v0.23.0
+    ghcr.io/trussiumhq/trussium:v1.22.0
 
 Digest-based image example:
 

--- a/docs/STATUS_AND_EVENTS.md
+++ b/docs/STATUS_AND_EVENTS.md
@@ -26,7 +26,7 @@ Example:
       observedGeneration: 4
       readyReplicas: 2
       availableReplicas: 2
-      currentImage: ghcr.io/trussiumhq/trussium:v0.23.0
+      currentImage: ghcr.io/trussiumhq/trussium:v1.22.0
       endpoint: http://private-ai.trussium.svc.cluster.local:9000
       conditions:
         - type: ConfigurationValid

--- a/docs/UPGRADES.md
+++ b/docs/UPGRADES.md
@@ -8,7 +8,7 @@ upgrade does not modify existing `TrussiumRuntime.spec.image` values.
 For the released manifest bundle, apply the target version:
 
 ```bash
-kubectl apply -f https://github.com/trussiumhq/trussium-operator/releases/download/v0.3.1/install.yaml
+kubectl apply -f https://github.com/trussiumhq/trussium-operator/releases/download/v1.0.1/install.yaml
 kubectl rollout status deployment/trussium-operator-controller-manager -n trussium-operator-system
 ```
 
@@ -16,7 +16,7 @@ For Helm installations, upgrade to an explicit chart version:
 
 ```bash
 helm upgrade trussium-operator oci://ghcr.io/trussiumhq/charts/trussium-operator \
-  --version 0.3.1 --namespace trussium-operator-system
+  --version 1.2.0 --namespace trussium-operator-system
 ```
 
 CI continuously validates release-to-release upgrades from representative
@@ -51,7 +51,7 @@ custom-resource specification.
 
 For example:
 
-    ghcr.io/trussiumhq/trussium:v0.24.0
+    ghcr.io/trussiumhq/trussium:v1.22.0
 
 or:
 
@@ -76,15 +76,15 @@ successful runtime.
 
 Example:
 
-    desiredImage: ghcr.io/trussiumhq/trussium:v0.24.0
-    currentImage: ghcr.io/trussiumhq/trussium:v0.24.0
-    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v0.23.0
+    desiredImage: ghcr.io/trussiumhq/trussium:v1.22.0
+    currentImage: ghcr.io/trussiumhq/trussium:v1.22.0
+    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v1.17.0
 
 After successful rollout completion:
 
-    desiredImage: ghcr.io/trussiumhq/trussium:v0.24.0
-    currentImage: ghcr.io/trussiumhq/trussium:v0.24.0
-    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v0.24.0
+    desiredImage: ghcr.io/trussiumhq/trussium:v1.22.0
+    currentImage: ghcr.io/trussiumhq/trussium:v1.22.0
+    lastSuccessfulImage: ghcr.io/trussiumhq/trussium:v1.22.0
 
 ## Initial Deployment
 


### PR DESCRIPTION
Closes #164

## Summary

Refresh current Operator task-guide examples to the supported release baseline.

## Changes

- Use Operator v1.0.1 and chart v1.2.0 in upgrade commands.
- Use runtime v1.22.0 in current Custom Resource and image-state examples.
- Preserve historical upgrade-matrix versions as historical references.

## Validation

- `git diff --check`
- Documentation-only change; repository CI validates the assembled documentation and Operator workflows.
