### PR TITLE
docs: clarify tested chart compatibility

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -46,6 +46,11 @@ The following is the current release snapshot:
 documented runtime integration contract. It is not a promise that every
 arbitrary runtime tag is compatible.
 
+Helm chart `v1.2.0` is the latest published chart and targets runtime
+`v1.22.0`. The matrix intentionally keeps `v1.1.0` for the `v1.22.0` row until
+the operator lifecycle is run against chart `v1.2.0`; do not interpret the
+latest published chart as lifecycle-tested by this repository.
+
 The `1.0.0` validation uses the stable runtime image and chart contract with
 an explicit runtime image override for lifecycle testing.
 


### PR DESCRIPTION
Closes #168

## Summary

Clarify the distinction between the latest published Helm chart and the operator lifecycle-tested matrix.

## Changes

- Document chart v1.2.0 as the latest published chart.
- Preserve v1.1.0 as the tested matrix entry until lifecycle evidence exists.

## Validation

- `git diff --check`
