### PR TITLE
docs: track latest Helm chart release

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -46,7 +46,7 @@ The following is the current release snapshot:
 documented runtime integration contract. It is not a promise that every
 arbitrary runtime tag is compatible.
 
-Helm chart `v1.2.0` is the latest published chart and targets runtime
+Helm chart `v1.3.0` is the latest published chart and targets runtime
 `v1.22.0`. The matrix intentionally keeps `v1.1.0` for the `v1.22.0` row until
 the operator lifecycle is run against chart `v1.2.0`; do not interpret the
 latest published chart as lifecycle-tested by this repository.


### PR DESCRIPTION
Closes #170

## Summary

Update the compatibility guide for the newly published Helm chart v1.3.0.

## Changes

- Identify v1.3.0 as the latest published chart targeting runtime v1.22.0.
- Preserve the distinction between publication and lifecycle-tested matrix entries.

## Validation

- `git diff --check`
