### PR TITLE
docs: refresh upgrade matrix baseline

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -48,7 +48,7 @@ arbitrary runtime tag is compatible.
 
 Helm chart `v1.3.0` is the latest published chart and targets runtime
 `v1.22.0`. The matrix intentionally keeps `v1.1.0` for the `v1.22.0` row until
-the operator lifecycle is run against chart `v1.2.0`; do not interpret the
+the operator lifecycle is run against chart `v1.3.0`; do not interpret the
 latest published chart as lifecycle-tested by this repository.
 
 The `1.0.0` validation uses the stable runtime image and chart contract with

--- a/docs/UPGRADE-MATRIX.md
+++ b/docs/UPGRADE-MATRIX.md
@@ -5,7 +5,7 @@ versions exercised by the release-to-release upgrade workflow.
 
 | Target operator release | Previous chart versions tested | Rollback tested |
 | --- | --- | --- |
-| v1.0.0 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
+| v1.0.1 / current release | v0.3.1, v0.5.0, v0.7.0, v0.9.0 | Yes |
 
 Each entry installs the published previous chart from the Trussium OCI
 registry, creates a `TrussiumRuntime`, upgrades to the current chart, verifies


### PR DESCRIPTION
Closes #172

## Summary

Refresh the published operator upgrade matrix baseline.

## Changes

- Identify operator v1.0.1 as the current release.
- Correct the latest published chart reference to v1.3.0.
- Preserve tested chart and rollback evidence.

## Validation

- `git diff --check`
