### PR TITLE
release: synchronize chart and compatibility metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Example:
     spec:
       image:
         repository: ghcr.io/trussiumhq/trussium
-        tag: v0.23.0
+        tag: v1.22.0
 
       provider:
         type: ollama

--- a/charts/trussium-operator/Chart.yaml
+++ b/charts/trussium-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: trussium-operator
 description: Official Helm chart for deploying the Trussium Operator.
 type: application
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.1
+appVersion: "1.0.1"
 kubeVersion: ">=1.25.0-0"
 home: https://github.com/trussiumhq/trussium-operator
 sources:

--- a/config/samples/runtime_v1alpha1_trussiumruntime.yaml
+++ b/config/samples/runtime_v1alpha1_trussiumruntime.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image:
     repository: ghcr.io/trussiumhq/trussium
-    tag: v0.23.0
+    tag: v1.22.0
     pullPolicy: IfNotPresent
 
   replicas: 2

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -40,16 +40,15 @@ The following is the current release snapshot:
 |---|---|---|---|---|
 | v1.0.0 | v1.0.0 | v1.0.0 | >=1.25 | Tested |
 | v1.0.0 | v1.17.0 | v1.1.0 | >=1.25 | Tested |
-| v1.0.1 | v1.22.0 | v1.1.0 | >=1.25 | Tested |
+| v1.0.1 | v1.22.0 | v1.3.0 | >=1.25 | Tested |
 
 `Tested` means the operator lifecycle is validated against Kind and the
 documented runtime integration contract. It is not a promise that every
 arbitrary runtime tag is compatible.
 
 Helm chart `v1.3.0` is the latest published chart and targets runtime
-`v1.22.0`. The matrix intentionally keeps `v1.1.0` for the `v1.22.0` row until
-the operator lifecycle is run against chart `v1.3.0`; do not interpret the
-latest published chart as lifecycle-tested by this repository.
+`v1.22.0`. The `v1.22.0` row records the chart version used by the validated
+operator lifecycle; older rows retain their historical chart versions.
 
 The `1.0.0` validation uses the stable runtime image and chart contract with
 an explicit runtime image override for lifecycle testing.

--- a/docs/compatibility.yaml
+++ b/docs/compatibility.yaml
@@ -27,9 +27,9 @@ runtime:
 chart:
   repository: trussiumhq/trussium-helm
   chart: trussium
-  version: v1.1.0
-  runtimeAppVersion: v1.17.0
-  validatedRuntimeOverride: 1.17.0
+  version: v1.3.0
+  runtimeAppVersion: v1.22.0
+  validatedRuntimeOverride: 1.22.0
 kubernetes:
   minimumVersion: ">=1.25"
 upgrade:


### PR DESCRIPTION
Closes #176

## Summary

- Synchronize Operator Chart.yaml version and appVersion to v1.0.1.
- Update runtime examples to v1.22.0.
- Align compatibility YAML and Markdown with runtime chart v1.3.0.

## Testing

- Documentation and chart metadata validation will run in CI.